### PR TITLE
Use getClobVal() to extract xmltype data

### DIFF
--- a/Ora2Pg.pm
+++ b/Ora2Pg.pm
@@ -3101,7 +3101,7 @@ sub _get_data
 		if ( $type->[$k] =~ /(date|time)/) {
 			$str .= "to_char($name->[$k], 'YYYY-MM-DD HH24:MI:SS'),";
 		} elsif ( $src_type->[$k] =~ /xmltype/i) {
-			$str .= "$alias.$name->[$k].extract('/').getStringVal(),";
+			$str .= "$alias.$name->[$k].extract('/').getClobVal(),";
 		} else {
 			$str .= "$name->[$k],";
 		}


### PR DESCRIPTION
Hi!

I think it's better to use getClobVal() to get the XML data out of an xmltype column. Without this, ora2pg fails on large XML documents. It seems to load fine for me with getClobVal(), I've been unable to spot anywhere that doesn't work.

//Magnus
