### PR TITLE
Backslash not escaped when using escape style syntax

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -3952,6 +3952,7 @@ sub format_data_row
 					$row->[$idx] =~ s/\0//gs;
 					$row->[$idx] = "'$row->[$idx]'";
 				} else {
+					$row->[$idx] =~ s/\\/\\\\/g;
 					$row->[$idx] =~ s/\0//gs;
 					$row->[$idx] = "E'$row->[$idx]'";
 				}


### PR DESCRIPTION
When using escape style syntax, backslashes have to be escaped.

Otherwise it could happen if the last character in a oracle string
is a backslash it would be exported as '...\' and wrongly escape
the ending single quote.
