### PR TITLE
Single quotes at the beginning of a string are not escaped

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -3947,6 +3947,7 @@ sub format_data_row
 				}
 			} elsif ($data_type =~ /(char|text|xml)/) {
 				$row->[$idx] =~ s/([^\\])'/$1''/gs; # escape single quote
+				$row->[$idx] =~ s/^'/''/gs;
 				if (!$self->{standard_conforming_strings}) {
 					$row->[$idx] =~ s/\\/\\\\/g;
 					$row->[$idx] =~ s/\0//gs;


### PR DESCRIPTION
The wrong behaviour was introduced by an earlier commit (01894cb) in an attempt to fix escaping of backslashed single quotes.

I'm not sure if this is the right way to fix the problem, seems a bit ugly to me.
I tried other ways to get it into one pattern, but those regular expressions are a pain.
