### PR TITLE
Bugfix: global_where gets overwritten

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -579,7 +579,7 @@ sub _init
 	}
 
 	# Set some default
-	$self->{global_where} = '';
+	$self->{global_where} ||= '';
 	$self->{prefix} = 'DBA';
 	if ($self->{user_grants}) {
 		$self->{prefix} = 'ALL';


### PR DESCRIPTION
read_config sets global_where on line 436, but this overwrites it.
This line should merely set a default if none is specified.
