### PR TITLE
Strip default "empty_clob()" values from table dumps

### DIFF
--- a/lib/Ora2Pg/PLSQL.pm
+++ b/lib/Ora2Pg/PLSQL.pm
@@ -258,9 +258,9 @@ sub plsql_to_plpgsql
 	$str =~ s/\bPROCEDURE\b/FUNCTION/igs;
 	# Simply remove this as not supported
 	$str =~ s/\bDEFAULT\s+NULL\b//igs;
-	# Replace DEFAULT empty_blob()
-	$str =~ s/empty_blob\(\s*\)//igs; 
-	$str =~ s/empty_blob\b//igs; 
+	# Replace DEFAULT empty_blob() and empty_clob()
+	$str =~ s/(empty_blob|empty_clob)\(\s*\)//igs;
+	$str =~ s/(empty_blob|empty_clob)\b//igs;
 
 	# dup_val_on_index => unique_violation : already exist exception
 	$str =~ s/\bdup_val_on_index\b/unique_violation/igs;


### PR DESCRIPTION
This function doesn't exist in Postgres and is not necessary.

This is identical to how empty_blob() was fixed in https://github.com/darold/ora2pg/issues/99. empty_clob is just another similar function for CLOB values: http://docs.oracle.com/cd/B19306_01/server.102/b14200/functions047.htm