### PR TITLE
Fix escaped commas not working properly in MODIFY_TYPE

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -7953,7 +7953,7 @@ sub read_config
 			$val =~ s/\\,/#NOSEP#/gs;
 			my @modif_type = split(/[,;]+/, $val);
 			foreach my $r (@modif_type) { 
-				$val =~ s/#NOSEP#/,/gs;
+				$r =~ s/#NOSEP#/,/gs;
 				my ($table, $col, $type) = split(/:/, lc($r));
 				$AConfig{$var}{$table}{$col} = $type;
 			}


### PR DESCRIPTION
A MODIFY_TYPE value like `TABLE1:COL4:decimal(9\,6)` was leading to a column like `col4 decimal(8#nosep#3)` in the SQL dump file that was generated. This fixes the output to be `col4 decimal(8,3)`.