### PR TITLE
Put parenthesis around AT TIME ZONE expression

### DIFF
--- a/lib/Ora2Pg/PLSQL.pm
+++ b/lib/Ora2Pg/PLSQL.pm
@@ -506,7 +506,7 @@ sub plsql_to_plpgsql
 	$str =~ s/TO_NUMBER\s*\(\s*TO_CHAR\s*\(([^,]+),\s*('[^']+')\s*\)\s*\)/to_char($1, $2)::integer/igs;
 
 	# Replace the UTC convertion with the PG syntaxe
-	 $str =~ s/SYS_EXTRACT_UTC\s*\(([^\)]+)\)/$1 AT TIME ZONE 'UTC'/isg;
+	$str =~ s/SYS_EXTRACT_UTC\s*\(([^\)]+)\)/($1 AT TIME ZONE 'UTC')/isg;
 
 	# Revert order in FOR IN REVERSE
 	$str =~ s/FOR(.*?)IN\s+REVERSE\s+([^\.\s]+)\s*\.\.\s*([^\s]+)/FOR$1IN REVERSE $3..$2/isg;


### PR DESCRIPTION
Such an Oracle DDL:
`"UTC_LAST_UPDATE_TIMESTAMP" TIMESTAMP (6) DEFAULT sys_extract_utc(systimestamp),`

was updated by ora2pg as follows:
`utc_last_update_timestamp timestamp DEFAULT CURRENT_TIMESTAMP AT TIME ZONE 'UTC',`

And I have added the parenthesis here to avoid the syntax error.