### PR TITLE
Fixed non-use of custom temp_dir (-T)

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -774,6 +774,9 @@ sub _init
 {
 	my ($self, %options) = @_;
 
+	# Use custom temp directory if specified
+	$TMP_DIR = $options{temp_dir} || $TMP_DIR;
+
 	# Read configuration file
 	$self->read_config($options{config}) if ($options{config});
 


### PR DESCRIPTION
The supplied temp_dir via cmdline argument -T is only used in the calling script for checking whether tmp-files remained, but the directory was not actually used in the Ora2Pg.pm itself, although supplied from the calling script via the %options.