### PR TITLE
add experimental DATADIFF functionality

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -387,6 +387,11 @@ DATADIFF	0
 # 2) length(suffix) + length(tablename) < NAMEDATALEN (usually 64)
 DATADIFF_DEL_SUFFIX _del
 DATADIFF_INS_SUFFIX _ins
+# Allow setting the work_mem and temp_buffers parameters
+# to keep temp tables in memory and have efficient sorting, etc.
+DATADIFF_WORK_MEM	256 MB
+DATADIFF_TEMP_BUFFERS	512 MB
+
 
 # The following are names of functions that will be called (via SELECT)
 # after the temporary tables have been reduced (by removing matching rows)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1003,6 +1003,10 @@ PG_SUPPORTS_CHECKOPTION	1
 # keywords in all generated statements.
 PG_SUPPORTS_IFEXISTS	1
 
+# PostgreSQL versions prior to 9.3 do not support the LATERAL keyword.
+# This is required for the DATADIFF feature.
+PG_SUPPORTS_LATERAL	1
+
 # Use btree_gin extenstion to create bitmap like index with pg >= 9.4
 # You will need to create the extension by yourself:
 #	create extension btree_gin;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -365,6 +365,52 @@ USE_UNACCENT		0
 #
 USE_LOWER_UNACCENT	0
 
+
+#------------------------------------------------------------------------------
+# DATA DIFF SECTION (only delete and insert actually changed rows)
+#------------------------------------------------------------------------------
+
+# EXPERIMENTAL! Not yet working correctly with partitioned tables, parallelism,
+# and direct postgres connection! Test before using in production!
+# This feature affects SQL output for data (INSERT or COPY).
+# The deletion and (re-)importing of data is redirected to temporary tables
+# (with configurable suffix) and matching entries (i.e. quadi-unchanged rows)
+# eliminated before actual application of the DELETE and INSERT.
+# Optional functions can be specified that are called before or after the
+# actual DELETE and INSERT per table, or after all tables have been processed.
+#
+# Enable DATADIFF functionality
+DATADIFF	0
+# Suffix for temporary tables holding rows to be deleted and to be inserted.
+# Pay attention to your tables names:
+# 1) There better be no two tables with names such that name1 + suffix = name2
+# 2) length(suffix) + length(tablename) < NAMEDATALEN (usually 64)
+DATADIFF_DEL_SUFFIX _del
+DATADIFF_INS_SUFFIX _ins
+
+# The following are names of functions that will be called (via SELECT)
+# after the temporary tables have been reduced (by removing matching rows)
+# and right before or right after the actual DELETE and INSERT are performed.
+# They must take three arguments, which should ideally be of type "regclass",
+# representing the real table, the "deletions" and the "insertions" temp table
+# names, respectively. They are called before re-activation of triggers,
+# indexes, etc. (if configured).
+#DATADIFF_BEFORE   my_datadiff_handler_function
+#DATADIFF_AFTER    my_datadiff_handler_function
+
+# Another function can be called (via SELECT) right before the entire COMMIT
+# (i.e., after re-activation of indexes, triggers, etc.), which will be
+# passed in Postgres ARRAYs of the table names of the real tables, the
+# "deletions" and the "insertions" temp tables, respectively, with
+# same array index positions belonging together. So this function should
+# take three arguments of type regclass[]
+#DATADIFF_AFTER_ALL    my_datadiff_bunch_handler_function
+# If in doubt, use schema-qualified function names here.
+# The search_path will have been set to PG_SCHEMA if EXPORT_SCHEMA == 1
+# (as defined by you in those config parameters, see above),
+# i.e., the "public" schema is not contained if EXPORT_SCHEMA == 1
+
+
 #------------------------------------------------------------------------------
 # CONSTRAINT SECTION (Control constraints export and import behaviors)
 #------------------------------------------------------------------------------

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -371,44 +371,49 @@ USE_LOWER_UNACCENT	0
 #------------------------------------------------------------------------------
 
 # EXPERIMENTAL! Not yet working correctly with partitioned tables, parallelism,
-# and direct postgres connection! Test before using in production!
+# and direct Postgres connection! Test before using in production!
 # This feature affects SQL output for data (INSERT or COPY).
 # The deletion and (re-)importing of data is redirected to temporary tables
-# (with configurable suffix) and matching entries (i.e. quadi-unchanged rows)
-# eliminated before actual application of the DELETE and INSERT.
+# (with configurable suffix) and matching entries (i.e. quasi-unchanged rows)
+# eliminated before actual application of the DELETE, UPDATE and INSERT.
 # Optional functions can be specified that are called before or after the
-# actual DELETE and INSERT per table, or after all tables have been processed.
+# actual DELETE, UPDATE and INSERT per table, or after all tables have been
+# processed.
 #
 # Enable DATADIFF functionality
 DATADIFF	0
+# Use UPDATE where changed columns can be matched by the primary key
+# (otherwise rows are DELETEd and re-INSERTed, which may interfere with
+# inverse foreign keys relationships!)
+DATADIFF_UPDATE_BY_PKEY	0
 # Suffix for temporary tables holding rows to be deleted and to be inserted.
 # Pay attention to your tables names:
 # 1) There better be no two tables with names such that name1 + suffix = name2
 # 2) length(suffix) + length(tablename) < NAMEDATALEN (usually 64)
 DATADIFF_DEL_SUFFIX _del
+DATADIFF_UPD_SUFFIX _upd
 DATADIFF_INS_SUFFIX _ins
 # Allow setting the work_mem and temp_buffers parameters
 # to keep temp tables in memory and have efficient sorting, etc.
 DATADIFF_WORK_MEM	256 MB
 DATADIFF_TEMP_BUFFERS	512 MB
 
-
 # The following are names of functions that will be called (via SELECT)
 # after the temporary tables have been reduced (by removing matching rows)
 # and right before or right after the actual DELETE and INSERT are performed.
-# They must take three arguments, which should ideally be of type "regclass",
-# representing the real table, the "deletions" and the "insertions" temp table
-# names, respectively. They are called before re-activation of triggers,
-# indexes, etc. (if configured).
+# They must take four arguments, which should ideally be of type "regclass",
+# representing the real table, the "deletions", the "updates", and the
+# "insertions" temp table names, respectively. They are called before
+# re-activation of triggers, indexes, etc. (if configured).
 #DATADIFF_BEFORE   my_datadiff_handler_function
 #DATADIFF_AFTER    my_datadiff_handler_function
 
 # Another function can be called (via SELECT) right before the entire COMMIT
 # (i.e., after re-activation of indexes, triggers, etc.), which will be
 # passed in Postgres ARRAYs of the table names of the real tables, the
-# "deletions" and the "insertions" temp tables, respectively, with
-# same array index positions belonging together. So this function should
-# take three arguments of type regclass[]
+# "deletions", the "updates" and the "insertions" temp tables, respectively,
+# with same array index positions belonging together. So this function should
+# take four arguments of type regclass[]
 #DATADIFF_AFTER_ALL    my_datadiff_bunch_handler_function
 # If in doubt, use schema-qualified function names here.
 # The search_path will have been set to PG_SCHEMA if EXPORT_SCHEMA == 1

--- a/README
+++ b/README
@@ -1790,6 +1790,11 @@ CONFIGURATION
         to add those keywords in all generated statements. Default value is
         1, enabled.
 
+    PG_SUPPORTS_LATERAL
+        PostgreSQL version prior to 9.3 do not support the LATERAL keyword.
+        This is required for the DATADIFF feature. Default value is
+        1, enabled.
+
     PG_SUPPORTS_ROLE (Deprecated)
         This option is deprecated since Ora2Pg release v7.3.
 

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -6398,9 +6398,9 @@ sub _dump_table
 		} else {
 			$col_list .= "\"$colname\",";
 			if ($f->[3] =~ m/^Y/) {
-				push @pg_colnames_nullable, "\L$colname\E";
+				push @pg_colnames_nullable, "\"$colname\"";
 			} else {
-				push @pg_colnames_notnull, "\L$colname\E";
+				push @pg_colnames_notnull, "\"$colname\"";
 			}
 		}
 	}

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -1372,6 +1372,9 @@ sub _init
 			if ($self->{datadiff} && $self->{pg_dsn}) {
 				$self->logit("FATAL: DATADIFF can not be used with direct import to PostgreSQL because direct import may load data in several transactions.\n", 0, 1);
 			}
+			if ($self->{datadiff} && !$self->{pg_supports_lateral}) {
+				$self->logit("FATAL: DATADIFF requires LATERAL support (Pg version 9.3 and above; see config parameter PG_SUPPORTS_LATERAL)\n", 0, 1);
+			}
 			$self->{dbhdest} = $self->_send_to_pgdb() if ($self->{pg_dsn} && !$self->{dbhdest});
 		}
 	}

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -5336,7 +5336,7 @@ LANGUAGE plpgsql ;
 
 		#### Set SQL commands that must be executed after data loading
 		my $footer = '';
-		my @datadiff_tbl, @datadiff_del, @datadiff_ins;
+		my (@datadiff_tbl, @datadiff_del, @datadiff_ins);
 		foreach my $table (@ordered_tables) {
 
 			# Rename table and double-quote it if required
@@ -6346,7 +6346,7 @@ sub _dump_table
 
 	# Extract column information following the Oracle position order
 	my @fname = ();
-	my @pg_colnames_nullable, @pg_colnames_notnull;
+	my (@pg_colnames_nullable, @pg_colnames_notnull);
 	foreach my $i ( 0 .. $#{$self->{tables}{$table}{field_name}} ) {
 		my $fieldname = ${$self->{tables}{$table}{field_name}}[$i];
 		if (!$self->{preserve_case}) {

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -5151,6 +5151,12 @@ LANGUAGE plpgsql ;
 
 			# Create temporary tables for DATADIFF
 			if ($self->{datadiff}) {
+				if ($self->{datadiff_work_mem}) {
+					$first_header .= "SET work_mem TO '" . $self->{datadiff_work_mem} . "';\n";
+				}
+				if ($self->{datadiff_temp_buffers}) {
+					$first_header .= "SET temp_buffers TO '" . $self->{datadiff_temp_buffers} . "';\n";
+				}
 				$first_header .= "CREATE TEMPORARY TABLE " . $self->get_tbname_with_suffix($tmptb, $self->{datadiff_del_suffix});
 				$first_header .= " (LIKE " . $tmptb . " INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES)";
 				$first_header .= " ON COMMIT DROP;\n";

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -5344,8 +5344,8 @@ LANGUAGE plpgsql ;
 				$footer .= "WITH del AS (SELECT t, row_number() OVER (PARTITION BY t.*) rownum, ctid FROM $tmptb_del t), ";
 				$footer .= "ins AS (SELECT t, row_number() OVER (PARTITION BY t.*) rownum, ctid FROM $tmptb_ins t), ";
 				$footer .= "paired AS (SELECT del.ctid ctid1, ins.ctid ctid2 FROM del JOIN ins ON del.t IS NOT DISTINCT FROM ins.t AND del.rownum = ins.rownum), ";
-				$footer .= "del_del AS (DELETE FROM $tmptb_del WHERE ctid IN (SELECT ctid1 FROM paired)), ";
-				$footer .= "del_ins AS (DELETE FROM $tmptb_ins WHERE ctid IN (SELECT ctid2 FROM paired)) ";
+				$footer .= "del_del AS (DELETE FROM $tmptb_del WHERE ctid = ANY(ARRAY(SELECT ctid1 FROM paired))), ";
+				$footer .= "del_ins AS (DELETE FROM $tmptb_ins WHERE ctid = ANY(ARRAY(SELECT ctid2 FROM paired))) ";
 				$footer .= "SELECT 1;\n";
 				# call optional function specified in config to be called before actual deletion/insertion
 				$footer .= "SELECT " . $self->{datadiff_before} . "('" . $tmptb . "', '" . $tmptb_del . "', '" . $tmptb_ins . "');\n" if ($self->{datadiff_before});

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -5284,7 +5284,8 @@ LANGUAGE plpgsql ;
 					for my $col (@pg_colnames_nullable) {
 						$footer .= "SELECT '$col'::TEXT WHERE old.$col <> new.$col OR ((old.$col IS NULL) <> (new.$col IS NULL)) UNION ALL "; 
 					}
-					$footer .= "SELECT '' WHERE FALSE) changed_columns FROM $tmptb_del old JOIN $tmptb_ins new USING (" . join(', ', @pg_colnames_pkey) . ")), ";
+					$footer .= "SELECT ''::TEXT WHERE FALSE) changed_columns FROM $tmptb_del old ";
+					$footer .= "JOIN $tmptb_ins new USING (" . join(', ', @pg_colnames_pkey) . ")), ";
 					$footer .= "del_del AS (DELETE FROM $tmptb_del WHERE ctid = ANY(ARRAY(SELECT ctid1 FROM upd))), ";
 					$footer .= "del_ins AS (DELETE FROM $tmptb_ins WHERE ctid = ANY(ARRAY(SELECT ctid2 FROM upd))) ";
 					$footer .= "INSERT INTO $tmptb_upd (old, new, changed_columns) SELECT old, new, changed_columns FROM upd;\n";


### PR DESCRIPTION
I added a functionality to "diff" existing against newly extracted data in Postgres via temporary tables, so that

- only new/deleted/changed rows are actually deleted from Postgres and/or inserted (anew)
- the "changeset" (maintained via temporary tables for deleted/inserted rows) can be further processed by functions that the user can define in Postgres

This is still experimental and especially does not yet work with partitioned tables, and maybe also not with parallel processing. You may or may not want to merge it, but I would be glad if you could review the enhancement and maybe make it compatible with partitioned tables, parallelism, etc, if you like. Any feedback and comments are appreciated.