### PR TITLE
update readme to provide tar command for bzip2 file

### DIFF
--- a/README
+++ b/README
@@ -122,7 +122,7 @@ INSTALLATION
     Like any other Perl Module Ora2Pg can be installed with the following
     commands:
 
-            tar xzf ora2pg-x.x.tar.gz
+            tar xjf ora2pg-x.x.tar.bz2
             cd ora2pg-x.x/
             perl Makefile.PL
             make && make install


### PR DESCRIPTION
This is a minor update to the readme. The current ora2pg package [available on SourceForge](https://sourceforge.net/projects/ora2pg/) is provided as a bzip2 file, so the correct command for decompression is `tar xjf`.