### PR TITLE
Handle translation of named parameters in function calls

### DIFF
--- a/lib/Ora2Pg/PLSQL.pm
+++ b/lib/Ora2Pg/PLSQL.pm
@@ -474,6 +474,9 @@ sub plsql_to_plpgsql
 	$str =~ s/FROM DUAL//igs;
 	$str =~ s/FROM SYS\.DUAL//igs;
 
+    # replace operator for named parameters in function calls
+    $str =~ s/=>/:=/gs;
+
 	# There's no such things in PostgreSQL
 	$str =~ s/PRAGMA RESTRICT_REFERENCES[^;]+;//igs;
         $str =~ s/PRAGMA SERIALLY_REUSABLE[^;]*;//igs;


### PR DESCRIPTION
Hello,

Here's a simple patch to translate named parameters. For instance:

```sql
SELECT fct(param => 1)
```

would be translated in
```sql
SELECT fct(param := 1)
```

I couldn't find any reference of `=>` for any other use than this, so I didn't tried to restrict to functions args only.  If it's a mistake, please tell me I'll try to fix it.