### PR TITLE
Skip default null values

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -8315,7 +8315,8 @@ END
 		}
 		
 		# Right trim Oracle default values
-		# A default text value is escaped with single quotes by Oracle, so a default value of whitespace(s) is not trimmed
+		# A default text value is escaped with single quotes by Oracle, so a whitespace default is kept, e.g. "' ' " -> "' '".
+		# An explicitly unset default value is returned as "NULL " by Oracle and is trimmed to "NULL".
 		$row->[4] =~ s/\s+$//;
 
 		my $tmptable = $row->[8];

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -8313,6 +8313,10 @@ END
 		if ( ($row->[1] eq 'NUMBER') && ($row->[6] eq '0') && ($row->[5] eq '') && ($row->[2] == 22) ) {
 			$row->[2] = 38;
 		}
+		
+		# Right trim Oracle default values
+		# A default text value is escaped with single quotes by Oracle, so a default value of whitespace(s) is not trimmed
+		$row->[4] =~ s/\s+$//;
 
 		my $tmptable = $row->[8];
 		if ($self->{export_schema} && !$self->{schema}) {


### PR DESCRIPTION
Empty and null default column values should be ignored during table ddl generation, see https://github.com/darold/ora2pg/blob/master/lib/Ora2Pg.pm#L6484

The default column value returned by Oracle contains a trailing whitespace. E.g. if the default column value is explicitly set to null (only way to 'drop' a default value in Oracle) the default value returned is 'NULL ' (trailing whitespace). Hence the check on line 6484 does not work.