### PR TITLE
fix  after commit 974c92c

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -6036,8 +6036,6 @@ BEGIN
 					$create_table_tmp .= "FOR VALUES";
 				}
 
-				$tb_name = $table . "_" if ($self->{prefix_partition});
-
 				my $check_cond = '';
 				my @condition = ();
 				my @ind_col = ();


### PR DESCRIPTION
Please see comment to the commit  974c92c , it look like this line is not needed as $tb_name is correctly defined few lines above (lines 6020 to 6029).