### PR TITLE
 add prefix_sub_partition

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -586,6 +586,9 @@ USE_INDEX_OPCLASS	0
 # could have the same name but different parent tables. This is not allowed,
 # table name must be unique. 
 PREFIX_PARTITION	0
+# Disable this directive if your subpartitions are dedicated to your partition 
+# (in case of your partition_name is a part of your subpartition_name)
+PREFIX_SUB_PARTITION 	1
 
 # If you don't want to reproduce the partitioning like in Oracle and want to
 # export all partitionned Oracle data into the main single table in PostgreSQL

--- a/README
+++ b/README
@@ -1353,6 +1353,12 @@ CONFIGURATION
         some partitions could have the same name but different parent
         tables. This is not allowed, table name must be unique.
 
+    PREFIX_SUB_PARTITION
+        Enable this directive if you want that your subpartition table name 
+        will be exported using the parent partition name. Enabled by default. 
+        If the partition names are a part of the subpartition names, you 
+        should enable this directive.
+
     DISABLE_PARTITION
         If you don't want to reproduce the partitioning like in Oracle and
         want to export all partitioned Oracle data into the main single

--- a/doc/Ora2Pg.pod
+++ b/doc/Ora2Pg.pod
@@ -1390,6 +1390,14 @@ multiple partitioned table, when exported to PostgreSQL some partitions
 could have the same name but different parent tables. This is not allowed,
 table name must be unique.
 
+
+=item PREFIX_SUB_PARTITION
+
+Enable this directive if you want that your subpartition table name will be
+exported using the parent partition name. Enabled by default. If the partition 
+names are a part of the subpartition names, you should enable this directive.
+
+
 =item DISABLE_PARTITION
 
 If you don't want to reproduce the partitioning like in Oracle and want to

--- a/doc/ora2pg.3
+++ b/doc/ora2pg.3
@@ -1520,6 +1520,11 @@ exported using the parent table name. Disabled by default. If you have
 multiple partitioned table, when exported to PostgreSQL some partitions
 could have the same name but different parent tables. This is not allowed,
 table name must be unique.
+.IP "\s-1PREFIX_SUB_PARTITION\s0" 4
+.IX Item "PREFIX_SUB_PARTITION"
+Enable this directive if you want that your subpartition table name will be exported
+using the parent partition name. Enabled by default. If the partition names are a part
+of the subpartition names, you should enable this directive.
 .IP "\s-1DISABLE_PARTITION\s0" 4
 .IX Item "DISABLE_PARTITION"
 If you don't want to reproduce the partitioning like in Oracle and want to

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -852,6 +852,7 @@ sub _init
 
 	# Used to precise if we need to prefix partition tablename with main tablename
 	$self->{prefix_partition} = 0;
+	$self->{prefix_part_subpartition} = 1;
 
 	# Use to preserve the data export type with geometry objects
 	$self->{local_type} = '';
@@ -6271,8 +6272,12 @@ BEGIN
 						my $sub_tb_name = $subpart;
 						$sub_tb_name =~ s/^[^\.]+\.//; # remove schema part if any
 						if ($self->{prefix_partition}) {
-							$sub_tb_name = "${tb_name}_$sub_tb_name";
-						}
+                                                	if ($self->{prefix_sub_partition}) {
+                                                                $sub_tb_name = "${tb_name}_$sub_tb_name";
+                                                        } else {
+                                                                $sub_tb_name = "${table}_$sub_tb_name";
+                                                        }
+                                                }
 						if (!$self->{quiet} && !$self->{debug}) {
 							print STDERR $self->progress_bar($ipos++, $total_partition, 25, '=', 'subpartitions', "generating $table/$part/$subpart" ), "\r";
 						}


### PR DESCRIPTION
Hello,
I'd like to add a parameter in case of the partition names are a part of the subpartition names.
I suggest this patch with the new directive prefix_sub_partition.
It can reduce the length of the inherit table name.
It seems to do the job in my case, but i don't know if there is another location in the code to adjust.
I let enabled by default for compatibility reason.
What do you think about it ?
Regards,
Manuel Pavy