### PR TITLE
Update Ora2Pg.pm

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -10189,6 +10189,9 @@ AND    IC.TABLE_OWNER = ?
 			if ($row->[-1] eq 'DESC') {
 				$row->[1] .= " DESC";
 			}
+		} else {
+                        # Quote column with unsupported symbols
+                        $row->[1] = $self->quote_object_name($row->[1]);
 		}
 
 		$row->[1] =~ s/SYS_EXTRACT_UTC\s*\(([^\)]+)\)/$1/isg;


### PR DESCRIPTION
Hi all!
I was unable to deploy to my PostgreSQL 9.4 some indexes with "#" symbol in column name. 
It looked like 
CREATE INDEX "z#ix_z#user_ref56" ON "z#user" (c_ud_doc#type);
My change covers the issue. But only for non-functional indexes