### PR TITLE
I791: Resolve Postgres table using its FQN during the TEST command invocation

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -15706,9 +15706,9 @@ sub _table_row_count
 		print "$lbl:$t:$tables_infos{$t}{num_rows}\n";
 		if ($self->{pg_dsn}) {
 			my ($tbmod, $orig, $schema, $both) = $self->set_pg_relation_name($t);
-			my $s = $self->{dbhdest}->prepare("SELECT count(*) FROM $tbmod;") or $self->logit("FATAL: " . $self->{dbhdest}->errstr . "\n", 0, 1);
+			my $s = $self->{dbhdest}->prepare("SELECT count(*) FROM $both;") or $self->logit("FATAL: " . $self->{dbhdest}->errstr . "\n", 0, 1);
 			if (not $s->execute) {
-				push(@errors, "Table $tbmod$orig does not exists in PostgreSQL database.") if ($s->state eq '42P01');
+				push(@errors, "Table $both$orig does not exists in PostgreSQL database.") if ($s->state eq '42P01');
 				next;
 			}
 			while ( my @row = $s->fetchrow()) {
@@ -18716,4 +18716,3 @@ L<DBD::Oracle>, L<DBD::Pg>
 
 
 =cut
-


### PR DESCRIPTION
Update the table row count logic to incorpate the Postgres table FQN as established through the set_pg_relation_name routine

Fixes #791 

Kudos to @gbylenok for identifying the issue and the fix