### PR TITLE
Make the build reproducible

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1147,7 +1147,7 @@ COMMENT_SAVEPOINT	0
 # set the regexp with the text capture to use to extract the text part.
 # For example with a variable declared as
 #       c_sample VARCHAR2(100 CHAR) := q'{This doesn't work.}';
-# the regexp must be: q'{(.*)}' ora2pg use the $$ delimiter.
+# the regexp must be: q'{(.*)}' ora2pg use the \$ delimiter.
 #ALTERNATIVE_QUOTING_REGEXP              q'{(.*)}'
 
 # If you want to use functions defined in the Orafce library and prevent


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) I noticed that `ora2pg` could not be built reproducibly.

This is because it generates a comment in a config file using `$$` in an attempt to get a literal `$` character. But `$$` inserts the
process PID (!) of the build process into the file instead.

This was originally filed in Debian as [#972336](https://bugs.debian.org/972336).