### PR TITLE
Allow Ora2PG to Include pseudocolumn RowID 

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -841,6 +841,11 @@ ENABLE_MICROSECOND      1
 # format. Only arrays of characters and numerics types are supported.
 #MODIFY_TYPE     
 
+# To include the ROWID pseudocolumn, assign a value of 1 using the
+# flag INCLUDE_ROWID_PSEUDOCOLUMN.  This must be used in conjunction with a
+# DATA_TYPE cast from ROWID to a Postgres datatype (eg. DATA_TYPE ROWID:text).
+# INCLUDE_ROWID_PSEUDOCOLUMN 1
+
 # By default Oracle call to function TO_NUMBER will be translated as a cast
 # into numeric. For example, TO_NUMBER('10.1234') is converted into PostgreSQL
 # call to_number('10.1234')::numeric. If you want you can cast the call to integer

--- a/README
+++ b/README
@@ -1870,7 +1870,7 @@ CONFIGURATION
         COPY and INSERT export type.
 
         About the ROWID and UROWID, they are converted into OID by "logical"
-        default but this will through an error at data import. There is no
+        default but this will throw an error at data import. There is no
         equivalent data type so you might want to use the DATA_TYPE
         directive to change the corresponding type in PostgreSQL. You should
         consider replacing this data type by a bigserial (autoincremented
@@ -1922,6 +1922,17 @@ CONFIGURATION
         Ora2Pg will take care to transform all data of this column in the
         correct format. Only arrays of characters and numerics types are
         supported.
+
+    INCLUDE_ROWID_PSEUDOCOLUMN
+        By default the ROWID pseudocolumn will not be translated into Postgres.
+        If you wish to include a ROWID column in Postgres, you can set
+        this value to 1. The column will be of type ROWID by default, which
+        will require using a data type translation.
+
+        We suggest using the flag DATA_TYPE and converting the OID Postgres
+        type into bigserial (autoincremented sequence), text or a
+        uuid data type.  Please read the ROWID section in the DATA_TYPE
+        documentation above for more information.
 
   Taking export under control
     The following other configuration directives interact directly with the

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -2235,6 +2235,9 @@ sub _tables
 				foreach my $c (keys %{$columns_infos{$tb}}) {
 					push(@{$self->{tables}{$tb}{column_info}{$c}}, @{$columns_infos{$tb}{$c}});
 				}
+        if ($self->{include_rowid_pseudocolumn}) {
+          push(@{$self->{tables}{$tb}{column_info}{'ROWID'}}, ('ROWID', 'ROWID', 10, 'N', undef, undef, undef, 0, $tb, $tables_infos{$tb}{owner}, 'NO'));
+        }
 			}
 			%columns_infos = ();
 


### PR DESCRIPTION
The change allows an Ora2PG user to add the RowID pseudocolumn in Oracle over to Postgres.

This column can often have value when replicating data and is sometimes used in replacement of a primary key.  Including RowID also fixes some errors in PL/SQL which were caused by the ROWID column being removed from the lexicon in Postgres.