### PR TITLE
Allow concurrent calls to ora2pg when using FDW and fixed FDW not using search path.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+MYMETA.json
+MYMETA.yml
+Makefile
+blib/
+ora2pg.conf.dist
+pm_to_blib
+

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -17913,6 +17913,7 @@ sub _show_infos
 						}
 					} keys %{$self->{tables}{$t}{column_info}})
 				{
+					$warning = '';
 					# COLUMN_NAME,DATA_TYPE,DATA_LENGTH,NULLABLE,DATA_DEFAULT,DATA_PRECISION,DATA_SCALE,CHAR_LENGTH,TABLE_NAME,OWNER,VIRTUAL_COLUMN,POSITION,AUTO_INCREMENT,SRID,SDO_DIM,SDO_GTYPE
 					my $d = $self->{tables}{$t}{column_info}{$k};
 					$d->[2] =~ s/\D//g;
@@ -17920,7 +17921,6 @@ sub _show_infos
 					$type1 = "$d->[1], $d->[2]" if (!$type1);
 
 					# Check if we need auto increment
-					$warning = '';
 					if ($d->[12] eq 'auto_increment' || $d->[12] eq '1')
 					{
 						if ($type1 !~ s/bigint/bigserial/)
@@ -18031,6 +18031,15 @@ sub _show_infos
 		}
 		$self->logit("----------------------------------------------------------\n", 0);
 		$self->logit("Total number of rows: $total_row_num\n\n", 0);
+
+		# Looking for Global temporary tables
+		my %global_tables = $self->_global_temp_table_info();
+		$self->logit("Global Temporary Tables:\n", 0);
+		foreach my $k (sort keys %global_tables) {
+			$self->logit("\t$k\n", 0);
+		}
+		$self->logit("\n\n", 0);
+
 		$self->logit("Top $self->{top_max} of tables sorted by number of rows:\n", 0);
 		$i = 1;
 		foreach my $t (sort {$tables_infos{$b}{num_rows} <=> $tables_infos{$a}{num_rows}} keys %tables_infos) {

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -56,7 +56,7 @@ our %ordered_views = ();
 
 # Character that must be escaped in COPY statement
 my $ESCAPE_COPY = { "\0" => "", "\\" => "\\\\", "\r" => "\\r", "\n" => "\\n", "\t" => "\\t"};
-my $FDW_SCHEMA = $ENV{FDW_SCHEMA} || 'ora2pg_fdw_import';
+my $FDW_SCHEMA = $ENV{FDW_SCHEMA} || '$FDW_SCHEMA';
 
 # Oracle internal timestamp month equivalent
 our %ORACLE_MONTHS = ('JAN'=>'01', 'FEB'=>'02','MAR'=>'03','APR'=>'04','MAY'=>'05','JUN'=>'06','JUL'=>'07','AUG'=>'08','SEP'=>'09','OCT'=>10,'NOV'=>11,'DEC'=>12);
@@ -2324,7 +2324,7 @@ sub _tables
 			%columns_infos = ();
 
 			# Retrieve comment of each columns and FK information if not foreign table export
-			if ($self->{type} ne 'FDW' and !$self->{oracle_fdw_data_export})
+			if ($self->{type} ne 'FDW' and (!$self->{oracle_fdw_data_export} || $self->{drop_fkey} || $self->{drop_indexes}))
 			{
 				if ($self->{type} eq 'TABLE')
 				{
@@ -7286,10 +7286,12 @@ sub export_table
 		$count_table++;
 
 		# Create FDW server if required
-		if ($self->{external_to_fdw}) {
-			if ( grep(/^$table$/i, keys %{$self->{external_table}}) ) {
-					$sql_header .= "CREATE EXTENSION IF NOT EXISTS file_fdw;\n\n" if ($sql_header !~ /CREATE EXTENSION .* file_fdw;/is);
-					$sql_header .= "CREATE SERVER \L$self->{external_table}{$table}{directory}\E FOREIGN DATA WRAPPER file_fdw;\n\n" if ($sql_header !~ /CREATE SERVER $self->{external_table}{$table}{directory} FOREIGN DATA WRAPPER file_fdw;/is);
+		if ($self->{external_to_fdw})
+		{
+			if ( grep(/^$table$/i, keys %{$self->{external_table}}) )
+			{
+				$sql_header .= "CREATE EXTENSION IF NOT EXISTS file_fdw;\n\n" if ($sql_header !~ /CREATE EXTENSION .* file_fdw;/is);
+				$sql_header .= "CREATE SERVER \L$self->{external_table}{$table}{directory}\E FOREIGN DATA WRAPPER file_fdw;\n\n" if ($sql_header !~ /CREATE SERVER $self->{external_table}{$table}{directory} FOREIGN DATA WRAPPER file_fdw;/is);
 			}
 		}
 
@@ -7321,8 +7323,8 @@ sub export_table
 			my $schem = '';
 
 			# Add the destination schema
-			if ($self->{external_to_fdw} && ($self->{type} eq 'INSERT' || $self->{type} eq 'COPY')) {
-				$sql_output .= "\nCREATE$foreign $obj_type $FDW_SCHEMA.$tbname (\n";
+			if ($self->{oracle_fdw_data_export} && ($self->{type} eq 'INSERT' || $self->{type} eq 'COPY')) {
+				 $sql_output .= "\nCREATE FOREIGN TABLE $FDW_SCHEMA.$tbname (\n";
 			} else {
 				$sql_output .= "\nCREATE$foreign $obj_type $tbname (\n";
 			}

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -6271,6 +6271,10 @@ sub export_type
 	}
 	if (!$sql_output) {
 		$sql_output = "-- Nothing found of type $self->{type}\n" if (!$self->{no_header});
+	} else {
+		if ($self->{export_schema} && ($self->{pg_schema} || $self->{schema})) {
+			$sql_header .= "CREATE SCHEMA IF NOT EXISTS " . $self->quote_object_name($self->{pg_schema} || $self->{schema}) . ";\n\n";
+		}
 	}
 	$self->dump($sql_header . $sql_output);
 

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -13575,7 +13575,7 @@ sub _get_partitions
 	return Ora2Pg::MySQL::_get_partitions($self) if ($self->{is_mysql});
 
 	my $highvalue = 'A.HIGH_VALUE';
-	if ($self->{db_version} =~ /Release [89]/) {
+	if ($self->{db_version} =~ /Release 8/) {
 		$highvalue = "'' AS HIGH_VALUE";
 	}
 	my $condition = '';
@@ -13610,7 +13610,8 @@ WHERE
 	}
 	$str .= $self->limit_to_objects('TABLE|PARTITION', 'A.TABLE_NAME|A.PARTITION_NAME');
 
-	if ($self->{prefix} ne 'USER') {
+	if ($self->{prefix} ne 'USER')
+	{
 		if ($self->{schema}) {
 			$str .= "\tAND A.TABLE_OWNER ='$self->{schema}' AND B.OWNER=A.TABLE_OWNER AND C.OWNER=A.TABLE_OWNER\n";
 		} else {
@@ -13624,11 +13625,13 @@ WHERE
 
 	my %parts = ();
 	my %default = ();
-	while (my $row = $sth->fetch) {
+	while (my $row = $sth->fetch)
+	{
 		if (!$self->{schema} && $self->{export_schema}) {
 			$row->[0] = "$row->[9].$row->[0]";
 		}
-		if ( ($row->[3] eq 'DEFAULT')) {
+		if ( ($row->[3] eq 'DEFAULT'))
+		{
 			$default{$row->[0]} = $row->[2];
 			next;
 		}

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -13112,7 +13112,11 @@ sub _get_types
 	# Retrieve all user defined types
 	my $str = "SELECT DISTINCT OBJECT_NAME,OWNER,OBJECT_ID FROM $self->{prefix}_OBJECTS WHERE OBJECT_TYPE='TYPE'";
 	$str .= " AND STATUS='VALID'" if (!$self->{export_invalid});
-	$str .= " AND OBJECT_NAME='$name'" if ($name);
+	if ($name) {
+		$str .= " AND OBJECT_NAME='$name'";
+	} else {
+		$str .= " AND OBJECT_NAME NOT LIKE 'SYS_PLSQL_%'"; # found in export from 9i
+	}
 	$str .= " AND GENERATED='N'";
 	if ($self->{schema}) {
 		$str .= "AND OWNER='$self->{schema}' ";
@@ -17640,7 +17644,7 @@ sub _show_infos
 				foreach my $t (sort keys %partitions) {
 					$report_info{'Objects'}{$typ}{'detail'} .= " $partitions{$t} $t partitions.\n";
 				}
-				$report_info{'Objects'}{$typ}{'comment'} = "Partitions are exported using table inheritance and check constraint. Hash and Key partitions are not supported by PostgreSQL and will not be exported.";
+				$report_info{'Objects'}{$typ}{'comment'} = "Partitions are well supported by PostgreSQL except key partition which will not be exported.";
 			}
 			elsif ($typ eq 'GLOBAL TEMPORARY TABLE')
 			{
@@ -20447,13 +20451,13 @@ sub _get_human_cost
 	if ($human_cost >= 420) {
 		my $tmp = $human_cost/420;
 		$tmp++ if ($tmp =~ s/\.\d+//);
-		$human_cost = "$tmp man-day(s)";
+		$human_cost = "$tmp person-day(s)";
 	} else {
 		#my $tmp = $human_cost/60;
 		#$tmp++ if ($tmp =~ s/\.\d+//);
 		#$human_cost = "$tmp man-hour(s)";
 		# mimimum to 1 day, hours are not really relevant
-		$human_cost = "1 man-day(s)";
+		$human_cost = "1 person-day(s)";
 	} 
 
 	return $human_cost;

--- a/lib/Ora2Pg/PLSQL.pm
+++ b/lib/Ora2Pg/PLSQL.pm
@@ -2220,6 +2220,9 @@ sub replace_sql_type
 	$str =~ s/\bVARCHAR(\s*(?!\())/text$1/igs;
 
 	foreach my $t ('DATE','LONG RAW','LONG','NCLOB','CLOB','BLOB','BFILE','RAW','ROWID','UROWID','FLOAT','DOUBLE PRECISION','INTEGER','INT','REAL','SMALLINT','BINARY_FLOAT','BINARY_DOUBLE','BINARY_INTEGER','BOOLEAN','XMLTYPE','SDO_GEOMETRY','PLS_INTEGER') {
+		if ($t eq 'DATE') {
+			$str =~ s/\b$t\s*\(\d\)/$data_type{$t}/igs;
+		}
 		$str =~ s/\b$t\b/$data_type{$t}/igs;
 	}
 

--- a/lib/Ora2Pg/PLSQL.pm
+++ b/lib/Ora2Pg/PLSQL.pm
@@ -2396,6 +2396,8 @@ sub estimate_cost
 		$cost_details{'DBMS_'} -= $n;
 		$n = () = $str =~ m/PLUNIT.ASSERT/igs;
 		$cost_details{'PLUNIT'} -= $n;
+		$n = () = $str =~ m/DBMS_SQL/igs;
+		$cost_details{'DBMS_'} -= $n;
 	}
 	$n = () = $str =~ m/\b(INSERTING|DELETING|UPDATING)\b/igs;
 	$cost_details{'TG_OP'} += $n;


### PR DESCRIPTION
1. Allow concurrent calls to ora2pg when using FDW by changing
'ora2pg_fdw_import' to use a different values at run time. This is done
by setting environment variable FDW_SCHEMA to the value to be used for 
the FDW schema.

2. Fixed problem with search path not being set when using FDW.