### PR TITLE
Fix ERROR:  function lower(smallint) does not exist

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -9146,7 +9146,7 @@ sub _dump_fdw_table
 				foreach my $k (keys %{$self->{ora_boolean_values}})
 				{
 					if ($self->{ora_boolean_values}{$k} eq 't') {
-						$true_list .= " lower(" . $self->quote_object_name($colname) .") = '$k' OR";
+						$true_list .= " lower(" . $self->quote_object_name($colname) ."::varchar) = '$k' OR";
 					}
 				}
 				$true_list =~ s/ OR$//;


### PR DESCRIPTION
Fix ERROR:  function lower(smallint) does not exist when copying data using oracle fdw and converting integer to boolean.