### PR TITLE
Fix fetching all-column-all-table properties for every table

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -10958,9 +10958,9 @@ sub _column_attributes
 	my ($self, $table, $owner, $objtype) = @_;
 
 	if ($self->{is_mysql}) {
-		return Ora2Pg::MySQL::_column_attributes($self,'',$owner,'TABLE');
+		return Ora2Pg::MySQL::_column_attributes($self,$table,$owner,'TABLE');
 	} else {
-		return Ora2Pg::Oracle::_column_attributes($self,'',$owner,'TABLE');
+		return Ora2Pg::Oracle::_column_attributes($self,$table,$owner,'TABLE');
 	}
 }
 


### PR DESCRIPTION
I have found ora2pg fetching all column information for all configured tables for every table. Such a metadata scan tooks a lot of time for database contains a lot of small tables. 