### PR TITLE
Path for function_per_file are MiXeD case enabled now

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -12885,7 +12885,7 @@ sub _convert_package
 		}
 		if ($self->{file_per_function})
 		{
-			my $dir = lc("$dirprefix$pname");
+			my $dir = "$dirprefix$pname";
 			if (!-d "$dir") {
 				if (not mkdir($dir)) {
 					$self->logit("Fail creating directory package : $dir - $!\n", 1);


### PR DESCRIPTION
We are use Oracle uppercase schema names at filesystem level during packages conversion with FILE_PER_FUNCTION enable.
The command itself is 
```$ ora2pg -d -p -t PACKAGE -n DOMAIN_SEC -N domain_sec -o package.sql -b ./DOMAIN_SEC/schema/packages -c ./DOMAIN_SEC/config/ora2pg.conf ```
It results in lowercaseing of filepath  ./DOMAIN_SEC/schema/packages supplied with -b option. That leads to mkdir() error. 
I can't find any reason for lowercasing the path.