### PR TITLE
Package names should be lowercased

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -12885,7 +12885,7 @@ sub _convert_package
 		}
 		if ($self->{file_per_function})
 		{
-			my $dir = "$dirprefix$pname";
+			my $dir = "$dirprefix".lc("$pname");
 			if (!-d "$dir") {
 				if (not mkdir($dir)) {
 					$self->logit("Fail creating directory package : $dir - $!\n", 1);


### PR DESCRIPTION
After some investigation we have found that while path part supplied by -b option can be mixed case,
package-name part of path should be in lower case