### PR TITLE
Fixed: postgres searchpath not being set in _dump_fdw_table

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -9433,6 +9433,9 @@ sub _dump_fdw_table
 	}
 	else
 	{
+		if ($search_path) {
+		  $local_dbh->do($search_path) or $self->logit("FATAL: " . $local_dbh->errstr . "\n", 0, 1);
+		}	
 		$self->logit("Exporting foreign table data for $table using query: $s_out\n", 1);
 		$local_dbh->do($s_out) or $self->logit("ERROR: " . $local_dbh->errstr . ", SQL: $s_out\n", 0);
 	}


### PR DESCRIPTION
I was have problems executing COPY using oracle FDW_SERVER between two different schemas because it couldn't find the tables.  Looking through the code I found code similar to what I added in my commit but wasn't there for this particular code path FDW was taking.  I copied the code here and it fixed the error I was getting.