### PR TITLE
Add a Dockerfile for running ora2pg in a container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:22.04
+
+RUN apt-get update \
+ && apt-get install -y  \
+         unzip \
+         curl \
+         ca-certificates \
+         rpm \
+         alien \
+         libaio1 \
+         # Install postgresql
+         postgresql-client \
+         # Install mysql
+         libdbd-mysql \
+         perl \
+         libcpan-distnameinfo-perl \
+         #install Perl Database Interface
+         libdbi-perl \
+         libpq-dev \
+         libdbd-pg-perl \
+         libio-compress-perl \
+         libtest-nowarnings-perl \
+         bzip2 \
+         git \
+&& 	apt-get clean
+
+ARG ORAVERSION=21
+ARG ORACLIENT_BASIC=https://download.oracle.com/otn_software/linux/instantclient/211000/oracle-instantclient-basic-21.1.0.0.0-1.x86_64.rpm
+ARG ORACLIENT_DEVEL=https://download.oracle.com/otn_software/linux/instantclient/211000/oracle-instantclient-devel-21.1.0.0.0-1.x86_64.rpm
+ARG ORACLIENT_SQLPLUS=https://download.oracle.com/otn_software/linux/instantclient/211000/oracle-instantclient-sqlplus-21.1.0.0.0-1.x86_64.rpm
+
+# Install Oracle Client
+RUN mkdir -p /usr/lib/oracle/$ORAVERSION/client64/network/admin \
+ && curl -L -o /tmp/oracle-instantclient.rpm $ORACLIENT_BASIC \
+ && (cd /tmp && alien -i ./oracle-instantclient.rpm && rm -f oracle-instantclient.rpm) \
+ && curl -L -o /tmp/oracle-instantclient.rpm $ORACLIENT_DEVEL \
+ && (cd /tmp && alien -i ./oracle-instantclient.rpm && rm -f oracle-instantclient.rpm) \
+ && curl -L -o /tmp/oracle-instantclient.rpm $ORACLIENT_SQLPLUS \
+ && (cd /tmp && alien -i ./oracle-instantclient.rpm && rm -f oracle-instantclient.rpm)
+
+ENV ORACLE_HOME=/usr/lib/oracle/$ORAVERSION/client64 \
+    TNS_ADMIN=/usr/lib/oracle/$ORAVERSION/client64/network/admin \
+    LD_LIBRARY_PATH=/usr/lib/oracle/$ORAVERSION/client64/lib \
+    PATH=$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/oracle/$ORAVERSION/client64/bin
+
+# Install Oracle DBD client
+RUN cpan install DBD::Oracle
+
+ARG ORA2PG_VERSION=v23.1
+# RUN git clone https://github.com/caffeine-01/ora2pg-1 \
+#   && (cd ora2pg-1 && git checkout $ORA2PG_VERSION && perl Makefile.PL && make && make install && rm -r ../ora2pg-1)
+RUN git clone https://github.com/darold/ora2pg.git \
+  && (cd ora2pg && git checkout $ORA2PG_VERSION && perl Makefile.PL && make && make install && rm -r ../ora2pg)
+
+ENTRYPOINT ["/usr/local/bin/ora2pg"]

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -9444,6 +9444,9 @@ sub _dump_fdw_table
 	}
 	else
 	{
+		if ($search_path) {
+			$local_dbh->do($search_path) or $self->logit("FATAL: " . $local_dbh->errstr . "\n", 0, 1);
+		}
 		$self->logit("Exporting foreign table data for $table using query: $s_out\n", 1);
 		$local_dbh->do($s_out) or $self->logit("ERROR: " . $local_dbh->errstr . ", SQL: $s_out\n", 0);
 	}


### PR DESCRIPTION
To build an image:
  docker build -t ora2pg .

To build an image using a particular ora2pg version:
  docker build --build-arg ORA2PG_VERSION=v23.0 -t ora2pg:v23.0 .
or from master/latest
 docker build --build-arg ORA2PG_VERSION=master -t ora2pg:latest .

Running Examples:
  Get the version:
    docker run --rm -it ora2pg --version
  Map a ora2pg.conf located in the users home directory.
    docker run --rm -it -v "$HOME:/root" ora2pg --conf /root/ora2pg.conf
