### PR TITLE
Fix typo in sqlnet.ora name (was sqlnet.or)

### DIFF
--- a/doc/Ora2Pg.pod
+++ b/doc/Ora2Pg.pod
@@ -588,7 +588,7 @@ to set some session parameters. This directive can be used multiple times.
 If your Oracle Client config file already includes the encryption method,
 then DBD:Oracle uses those settings to encrypt the connection while you
 extract the data. For example if you have configured the Oracle Client
-config file (sqlnet.or or .sqlnet) with the following information:
+config file (sqlnet.ora or .sqlnet) with the following information:
 
 	# Configure encryption of connections to Oracle
 	SQLNET.ENCRYPTION_CLIENT = required

--- a/doc/ora2pg.3
+++ b/doc/ora2pg.3
@@ -750,7 +750,7 @@ to set some session parameters. This directive can be used multiple times.
 If your Oracle Client config file already includes the encryption method,
 then DBD:Oracle uses those settings to encrypt the connection while you
 extract the data. For example if you have configured the Oracle Client
-config file (sqlnet.or or .sqlnet) with the following information:
+config file (sqlnet.ora or .sqlnet) with the following information:
 .PP
 .Vb 4
 \&        # Configure encryption of connections to Oracle


### PR DESCRIPTION
Correcting a minor typo that might cause those not familiar with Oracle Database configuration files some confusion.