### PR TITLE
Fix for Issue #1612

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -12109,8 +12109,8 @@ sub _count_source_rows
 		$tbname = "[$t]";
 		$tbname =~ s/\./\].\[/;
 	} else {
-		$tbname = $t;
-		$tbname = $self->{schema} . '.' . $t if ($self->{schema} && $t !~ /\./);
+		$tbname = qq["$t"];
+		$tbname = qq["$self->{schema}"] . '.' . qq["$t"] if ($self->{schema} && $t !~ /\./);
 	}
 	my $sql = "SELECT COUNT(*) FROM $tbname";
 	my $sth = $dbh->prepare( $sql ) or $self->logit("FATAL: " . $dbh->errstr . "\n", 0, 1);


### PR DESCRIPTION
Fix for issue https://github.com/darold/ora2pg/issues/1612 by making the Oracle schema and table name quoted identifiers in `SELECT COUNT(*) ...`  statement.

Note: this means that the lower-case comparison of the PostgreSQL and Oracle object names will not match exactly in line 17021 of subroutine **set_pg_relation_name**:

```perl
        $orig = " (origin: $table)" if (lc($cmptb) ne lc($table));

```

And the resulting output will show something similar to:

```
ORACLEDB:"MY_SCHEMA"."my_table":13
POSTGRES:my_table (origin: "MY_SCHEMA"."my_table"):13
```

Which is probably fine as it shows the object names with quoted accuracy. However, if not desirable, this the comparison of `lc($table)` in line 17021 could be modified to strip the double quotes.