### PR TITLE
Fix for Issue #1610

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -12113,8 +12113,8 @@ sub _count_source_rows
 		$tbname = $self->{schema} . '.' . $t if ($self->{schema} && $t !~ /\./);
 	}
 	my $sql = "SELECT COUNT(*) FROM $tbname";
-	my $sth = $dbh->prepare( $sql ) or $self->logit("FATAL: " . $dbh->errstr . "\n", 0, 1);
-	$sth->execute or $self->logit("FATAL: " . $dbh->errstr . "\n", 0, 1);
+	my $sth = $dbhsrc->prepare( $sql ) or $self->logit("FATAL: " . $dbhsrc->errstr . "\n", 0, 1);
+	$sth->execute or $self->logit("FATAL: " . $dbhsrc->errstr . "\n", 0, 1);
 	my $size = $sth->fetch();
 	$sth->finish();
 


### PR DESCRIPTION
Fix `$dbh` typo in subroutine **_count_source_rows** as described in Issue #1610 .  Actual database handle variable is `$dbhsrc`.

Without fix, the following error will be returned:

```
Can't call method "prepare" on an undefined value at /usr/local/share/perl5/Ora2Pg.pm line 12116.
```

Typo fixes in this PR resolves this small issue.