### PR TITLE
Fix for Issue #1617

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -12215,7 +12215,12 @@ sub _table_info
 		foreach my $s (@ret)
 		{
 			my ($tb, $cnt) = split(':', $s);
-			$tables_infos{$tb}{num_rows} = $cnt || 0;
+			chomp $cnt;
+			$tb =~ s/"//g;
+			my ($ora_owner, $ora_table) = split('\.', $tb);
+			if ($tables_infos{$ora_table}{owner} eq $ora_owner) {
+				$tables_infos{$ora_table}{num_rows} = $cnt || 0;
+			}
 		}
 
 		my $t2 = Benchmark->new;


### PR DESCRIPTION
Fix to problem as described in detail in Issue #1617 .  Specifically:

1. Eliminate training carriage return with the row count value by using a `chomp`.
2. Remove quotes from the owner and table names (quoted identifier) and split the table name string -- which as per pull request #1619 will mean that the `$tb` table name variable does include the schema and is quoted.
4. Update the proper table name value in the `$tables_infos` hash but only if both the `$ora_table` hash key and `$ora_owner` hash value matches.