### PR TITLE
Fix for Issue #1381

### DIFF
--- a/README
+++ b/README
@@ -536,6 +536,11 @@ CONFIGURATION
         To connect to a local ORACLE instance with connections "as sysdba"
         you have to set ORACLE_USER to "/" and an empty password.
 
+        To make a connection using an Oracle Secure External Password Store
+        (SEPS), first configure the Oracle Wallet and then set both the
+        ORACLE_USER and ORACLE_PWD directives to the special value of "__SEPS__"
+        (without the quotes but with the double underscore).
+
     USER_GRANTS
         Set this directive to 1 if you connect the Oracle database as simple
         user and do not have enough grants to extract things from the

--- a/doc/Ora2Pg.pod
+++ b/doc/Ora2Pg.pod
@@ -539,6 +539,12 @@ ORACLE_USER is not set it will be asked interactively too.
 To connect to a local ORACLE instance with connections "as sysdba" you have to
 set ORACLE_USER to "/" and an empty password.
 
+To make a connection using an Oracle Secure External Password Store (SEPS), 
+first configure the Oracle Wallet and then set both the ORACLE_USER and 
+ORACLE_PWD directives to the special value of "__SEPS__" (without the quotes 
+but with the double underscore).
+
+
 =item USER_GRANTS
 
 Set this directive to 1 if you connect the Oracle database as simple user and

--- a/lib/Ora2Pg/Oracle.pm
+++ b/lib/Ora2Pg/Oracle.pm
@@ -134,7 +134,9 @@ sub _db_connection
 	$self->logit("NLS_NCHAR = $ENV{NLS_NCHAR}\n", 1);
 	$self->logit("Trying to connect to database: $self->{oracle_dsn}\n", 1) if (!$self->{quiet});
 
-	my $dbh = DBI->connect($self->{oracle_dsn}, $self->{oracle_user}, $self->{oracle_pwd},
+	my $dbh = DBI->connect($self->{oracle_dsn}, 
+		( $self->{oracle_user} eq "__SEPS__" ? "" : $self->{oracle_user} ),
+		( $self->{oracle_pwd}  eq "__SEPS__" ? "" : $self->{oracle_pwd}  ),
 		{
 			ora_envhp => 0,
 			LongReadLen=>$self->{longreadlen},


### PR DESCRIPTION
**Adding additional functionality related to an old** Issue #1381.

Sometimes it is desirable to keep the Oracle password out of plain text OS files including the Ora2Pg configuration file.  Instead it is a little safer to keep the Oracle credentials in an Oracle Wallet file and then make a password-less connection based on having that Wallet file.  Essentially a little bit similar to using ssh with a private key file.

This version of an Oracle Wallet file is called a Secure External Password Store or SEPS.  Oracle documentation reference: https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/configuring-authentication.html#GUID-803496D2-19C7-4F02-94EC-C13EDD8FB17B

With an Oracle Wallet/SEPS connection, no username or password is required.  For example with SQL Plus the connection simply becomes:
```
sqlplus /@ORCL
```

In this example, a specific username and password was used.  It was just not provided at the command line and instead it was obtained from the Oracle Wallet file.

With Perl, the functionality is similar - the username and password is removed so the database handle connection line would change from this:

```perl
my $dbh = DBI->connect($self->{oracle_dsn}, $self->{oracle_user}, $self->{oracle_pwd},
```

To this:

```perl
my $dbh = DBI->connect($self->{oracle_dsn}, '', '',
```

**But I don't want to change any existing functionality in any way.**

So to make this solution dynamic and to not break any other functionality, and allowing it to still prompt for a username and password if one is not included in the configuration file (as it currently does), **this PR includes new capabilities**.

Specifically: if the the **ORACLE_USER** and **ORACLE_PWD** fields are set to the special string of `__SEPS__` then the database handle connection changes.

Example in the configuration file:
```
$ grep '^ORACLE_USER\|ORACLE_PWD' config/ora2pg.conf
ORACLE_USER      __SEPS__
ORACLE_PWD       __SEPS__
```

And the **Oracle.pm** logic changes to make the database username and password fields dynamic in the database handle connection:

```perl
       my $dbh = DBI->connect($self->{oracle_dsn},
               ( $self->{oracle_user} eq "__SEPS__" ? "" : $self->{oracle_user} ),
               ( $self->{oracle_pwd}  eq "__SEPS__" ? "" : $self->{oracle_pwd}  ),
```

Meaning: if the ORACLE_USER/PWD field is `__SEPS__`, then use an empty string for the connection.  Otherwise, use the set value.

---

Documentation updated accordingly in this PR.