### PR TITLE
Fix for Issue #1627

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -17013,7 +17013,7 @@ sub show_test_errors
 	if ($#errors >= 0)
 	{
 		foreach my $msg (@errors) {
-			print "FINDING: $msg\n";
+			print "DIFF: $msg\n";
 		}
 	}
 	else

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -17013,7 +17013,7 @@ sub show_test_errors
 	if ($#errors >= 0)
 	{
 		foreach my $msg (@errors) {
-			print "$msg\n";
+			print "FINDING: $msg\n";
 		}
 	}
 	else


### PR DESCRIPTION
Simple one line suggested enhancement to resolve Issue #1627 .

Of course, if desired some keyword other that `FINDING` could be used.  For example, change to something else such as `DIFFERENCE` or even `ERROR DETAILS` if preferred.  Point isn't the actual word per say, but rather that some unique prefix or keyword is used so these lines can be easily identified from a grep command, etc.