### PR TITLE
Extending the enhancement in Pull Request #1621 to the Oracle_FDW use…

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -20500,6 +20500,10 @@ sub _create_foreign_server
 	my $usrlbl = 'user';
 	$usrlbl = 'username' if ($self->{is_mysql});
 	my $sql = "CREATE USER MAPPING IF NOT EXISTS FOR $self->{pg_user} SERVER $self->{fdw_server} OPTIONS ($usrlbl '$self->{oracle_user}', password '$self->{oracle_pwd}');";
+	if ($self->{oracle_user} eq "__SEPS__" && $self->{oracle_pwd} eq "__SEPS__")  # Replace with empty credentials for an Oracle Wallet connection
+	{
+		$sql =~ s/__SEPS__//g;
+	}
 	$self->{dbhdest}->do($sql) or $self->logit("FATAL: " . $self->{dbhdest}->errstr . "\n", 0, 1);
 }
 


### PR DESCRIPTION
One final enhancement related to Issue #1381, and specifically the use of Oracle Wallets to hold the Oracle database credentials.

In this specific PR, the same functionality is extended to the Oracle_FDW user mapping.  Logic of the PR suggested change is:
_If the Oracle user and password directives are set to the special marker string (from the previous enhancement changes) then leave them as empty strings in the Oracle_FDW user mapping._

Tested this change and it works successfully as expected:

If the `ORACLE_USER` and the `ORACLE_PWD` directives are set to the special marker string in the configuration file then the Ora2Pg created user mapping will look like:
```
  oid  | umuser | umserver |     umoptions
-------+--------+----------+-------------------
 43010 |  30576 |    43009 | {user=,password=}
```
And data copy through the Oracle_FDW will work successfully, leveraging the Oracle Wallet!

But if the `ORACLE_USER` and the `ORACLE_PWD` directives are set to actual values in the configuration file, then the Ora2Pg created user mapping still works as expected (meaning in exactly the same way as before):
```
  oid  | umuser | umserver |          umoptions
-------+--------+----------+-----------------------------
 42756 |  30576 |    42755 | {user=SCOTT,password=******}
```