### PR TITLE
Include modify_struct/exclude_columns on Postgres side in test_data

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -21259,6 +21259,7 @@ ORDER BY attnum};
 	my @dest_types = ();
 	while ( my @crow = $tmpsth->fetchrow())
 	{
+		next if (!$self->is_in_struct($tb, $crow[0]));
 		if ($crow[2] eq 'geometry')
 		{
 			if ($self->{is_mysql}) {


### PR DESCRIPTION
When running `TEST_DATA` with directives `MODIFY_STRUCT` or `EXCLUDE_COLUMNS`, only the Oracle side is modified. This PR uses the function `is_in_struct` to modify the Postgres list of columns.