### PR TITLE
fixed warning about uninitialized use of

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -4221,11 +4221,12 @@ sub _export_table_data
 		}
 	}
 
+	# Set search path
+	my $search_path = $self->set_search_path();
+
 	# Add table truncate order if there's no global DELETE clause or one specific to the current table
 	if ($self->{truncate_table} && !$self->{global_delete} && !exists $self->{delete}{"\L$table\E"})
 	{
-		# Set search path
-		my $search_path = $self->set_search_path();
 		if ($self->{pg_dsn} && !$self->{oracle_speed})
 		{
 			if ($search_path)


### PR DESCRIPTION
the variable is used in other scoped, too

maybe using

```perl
use warnings FATAL => 'all';
use strict;
```

is a good idea, as there are a lot of other warnings that might indicate bugs.