### PR TITLE
Avoid exporting tables with two partition keys with the same name

### DIFF
--- a/lib/Ora2Pg/Oracle.pm
+++ b/lib/Ora2Pg/Oracle.pm
@@ -2215,7 +2215,7 @@ sub _get_partitions
 	}
 	# Retrieve all partitions.
 	my $str = qq{
-SELECT
+SELECT DISTINCT
 	A.TABLE_NAME,
 	A.PARTITION_POSITION,
 	A.PARTITION_NAME,
@@ -2295,7 +2295,7 @@ sub _get_subpartitions
 	}
 	# Retrieve all partitions.
 	my $str = qq{
-SELECT
+SELECT DISTINCT
 	A.TABLE_NAME,
 	A.SUBPARTITION_POSITION,
 	A.SUBPARTITION_NAME,
@@ -2374,7 +2374,7 @@ sub _get_partitions_list
 	}
 	# Retrieve all partitions.
 	my $str = qq{
-SELECT
+SELECT DISTINCT
 	A.TABLE_NAME,
 	A.PARTITION_POSITION,
 	A.PARTITION_NAME,
@@ -2433,7 +2433,7 @@ sub _get_partitioned_table
 		$condition .= " AND B.OWNER NOT IN ('" . join("','", @{$self->{sysusers}}) . "') ";
 	}
 	# Retrieve all partitions.
-	my $str = "SELECT B.TABLE_NAME, B.PARTITIONING_TYPE, B.OWNER, B.PARTITION_COUNT, B.SUBPARTITIONING_TYPE";
+	my $str = "SELECT DISTINCT B.TABLE_NAME, B.PARTITIONING_TYPE, B.OWNER, B.PARTITION_COUNT, B.SUBPARTITIONING_TYPE";
 	if ($self->{type} !~ /SHOW|TEST/)
 	{
 		$str .= ", C.COLUMN_NAME, C.COLUMN_POSITION";


### PR DESCRIPTION
By querying the database partition by SQL, there may be two identical partition records, and use distinct to remove duplicate partition records