### PR TITLE
The same partition name appears when creating a partitioned table 

### DIFF
--- a/lib/Ora2Pg/Oracle.pm
+++ b/lib/Ora2Pg/Oracle.pm
@@ -2215,7 +2215,7 @@ sub _get_partitions
 	}
 	# Retrieve all partitions.
 	my $str = qq{
-SELECT DISTINCT
+SELECT
 	A.TABLE_NAME,
 	A.PARTITION_POSITION,
 	A.PARTITION_NAME,
@@ -2231,6 +2231,7 @@ WHERE
 	a.table_name = b.table_name AND
 	(b.partitioning_type = 'RANGE' OR b.partitioning_type = 'LIST' OR b.partitioning_type = 'HASH')
 	AND a.table_name = c.name
+        AND C.OBJECT_TYPE = 'TABLE'
 	$condition
 };
 
@@ -2295,7 +2296,7 @@ sub _get_subpartitions
 	}
 	# Retrieve all partitions.
 	my $str = qq{
-SELECT DISTINCT
+SELECT
 	A.TABLE_NAME,
 	A.SUBPARTITION_POSITION,
 	A.SUBPARTITION_NAME,
@@ -2312,6 +2313,7 @@ WHERE
 	a.table_name = b.table_name AND
 	(b.subpartitioning_type = 'RANGE' OR b.subpartitioning_type = 'LIST' OR b.subpartitioning_type = 'HASH')
 	AND a.table_name = c.name
+        AND C.OBJECT_TYPE = 'TABLE'
 	$condition
 };
 	$str .= $self->limit_to_objects('TABLE|PARTITION', 'A.TABLE_NAME|A.SUBPARTITION_NAME');
@@ -2438,7 +2440,7 @@ sub _get_partitioned_table
 	{
 		$str .= ", C.COLUMN_NAME, C.COLUMN_POSITION";
 		$str .= " FROM $self->{prefix}_PART_TABLES B, $self->{prefix}_PART_KEY_COLUMNS C";
-		$str .= " WHERE B.TABLE_NAME = C.NAME AND (B.PARTITIONING_TYPE = 'RANGE' OR B.PARTITIONING_TYPE = 'LIST' OR B.PARTITIONING_TYPE = 'HASH')";
+		$str .= " WHERE B.TABLE_NAME = C.NAME AND (B.PARTITIONING_TYPE = 'RANGE' OR B.PARTITIONING_TYPE = 'LIST' OR B.PARTITIONING_TYPE = 'HASH') AND C.OBJECT_TYPE = 'TABLE'";
 	}
 	else
 	{

--- a/lib/Ora2Pg/Oracle.pm
+++ b/lib/Ora2Pg/Oracle.pm
@@ -2376,7 +2376,7 @@ sub _get_partitions_list
 	}
 	# Retrieve all partitions.
 	my $str = qq{
-SELECT DISTINCT
+SELECT
 	A.TABLE_NAME,
 	A.PARTITION_POSITION,
 	A.PARTITION_NAME,
@@ -2435,7 +2435,7 @@ sub _get_partitioned_table
 		$condition .= " AND B.OWNER NOT IN ('" . join("','", @{$self->{sysusers}}) . "') ";
 	}
 	# Retrieve all partitions.
-	my $str = "SELECT DISTINCT B.TABLE_NAME, B.PARTITIONING_TYPE, B.OWNER, B.PARTITION_COUNT, B.SUBPARTITIONING_TYPE";
+	my $str = "SELECT B.TABLE_NAME, B.PARTITIONING_TYPE, B.OWNER, B.PARTITION_COUNT, B.SUBPARTITIONING_TYPE";
 	if ($self->{type} !~ /SHOW|TEST/)
 	{
 		$str .= ", C.COLUMN_NAME, C.COLUMN_POSITION";

--- a/lib/Ora2Pg/Oracle.pm
+++ b/lib/Ora2Pg/Oracle.pm
@@ -2215,7 +2215,7 @@ sub _get_partitions
 	}
 	# Retrieve all partitions.
 	my $str = qq{
-SELECT
+SELECT DISTINCT
 	A.TABLE_NAME,
 	A.PARTITION_POSITION,
 	A.PARTITION_NAME,
@@ -2295,7 +2295,7 @@ sub _get_subpartitions
 	}
 	# Retrieve all partitions.
 	my $str = qq{
-SELECT
+SELECT DISTINCT
 	A.TABLE_NAME,
 	A.SUBPARTITION_POSITION,
 	A.SUBPARTITION_NAME,
@@ -2374,7 +2374,7 @@ sub _get_partitions_list
 	}
 	# Retrieve all partitions.
 	my $str = qq{
-SELECT
+SELECT DISTINCT
 	A.TABLE_NAME,
 	A.PARTITION_POSITION,
 	A.PARTITION_NAME,
@@ -2433,7 +2433,7 @@ sub _get_partitioned_table
 		$condition .= " AND B.OWNER NOT IN ('" . join("','", @{$self->{sysusers}}) . "') ";
 	}
 	# Retrieve all partitions.
-	my $str = "SELECT B.TABLE_NAME, B.PARTITIONING_TYPE, B.OWNER, B.PARTITION_COUNT, B.SUBPARTITIONING_TYPE";
+	my $str = "SELECT DISTINCT B.TABLE_NAME, B.PARTITIONING_TYPE, B.OWNER, B.PARTITION_COUNT, B.SUBPARTITIONING_TYPE";
 	if ($self->{type} !~ /SHOW|TEST/)
 	{
 		$str .= ", C.COLUMN_NAME, C.COLUMN_POSITION";


### PR DESCRIPTION
Oracle allows the same table name and index name, so two records may appear in the query DBA__PART_KEY_COLUMNS, DBA_SUBPART_KEY_COLUMNS and DBA__PART_KEY_COLUMNS, object_type table and index. Causes functions such as _get_partitions, _get_subpartitions, _get_partitioned_table, and so on to log two results, and eventually, two identical partition keys exist for a table