### PR TITLE
Double quote $col when reserved keyword  #1678

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -11030,7 +11030,7 @@ sub _create_check_constraint
 		{
 			my $col = $1;
 			$col =~ s/"//g;
-			$col = '"' . $col . '"' if ($self->{preserve_case} || ($self->{use_reserved_words} && $self->is_reserved_words($col));
+			$col = '"' . $col . '"' if ($self->{preserve_case} || $self->{use_reserved_words} && $self->is_reserved_words($col));
 			$out .= "ALTER TABLE $table ALTER COLUMN $col SET NOT NULL;\n";
 		}
 		else

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -11030,7 +11030,7 @@ sub _create_check_constraint
 		{
 			my $col = $1;
 			$col =~ s/"//g;
-			$col = '"' . $col . '"' if ($self->{preserve_case} || $self->is_reserved_words($col));
+			$col = '"' . $col . '"' if ($self->{preserve_case} || ($self->{use_reserved_words} && $self->is_reserved_words($col));
 			$out .= "ALTER TABLE $table ALTER COLUMN $col SET NOT NULL;\n";
 		}
 		else

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -11030,7 +11030,7 @@ sub _create_check_constraint
 		{
 			my $col = $1;
 			$col =~ s/"//g;
-			$col = '"' . $col . '"' if ($self->{preserve_case});
+			$col = '"' . $col . '"' if ($self->{preserve_case} || $self->is_reserved_words($col));
 			$out .= "ALTER TABLE $table ALTER COLUMN $col SET NOT NULL;\n";
 		}
 		else


### PR DESCRIPTION
When generating the statement 'ALTER TABLE $table ALTER COLUMN $col SET NOT NULL', $col should be double quoted if it's a reserved keyword