### PR TITLE
added testcase for _convert_function

### DIFF
--- a/t/01_convertfunction.t
+++ b/t/01_convertfunction.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::Simple tests => 1;
+use Ora2Pg;
+
+my $function = "CREATE FUNCTION get_bal(acc_no IN NUMBER)
+   RETURN NUMBER
+   IS acc_bal NUMBER(11,2);
+   BEGIN
+      SELECT order_total
+      INTO acc_bal
+      FROM orders
+      WHERE customer_id = acc_no;
+      RETURN(acc_bal);
+    END;
+/";
+my $ora2pg = new Ora2Pg(datasource => 'DBI:Mock:', user => 'mock', password => 'mock');
+my $converted = $ora2pg->_convert_function("foo", $function, "");
+
+ok($converted eq "", "Convert function failed with statement: " . $converted);


### PR DESCRIPTION
I do not yet fully understand the needed parameters for the function and this should only serve as a base for further discussions

call this with:

`perl -Ilib t/*.t`

This would allow users to report failing conversions with simple test cases that everyone can reproduce easily