### PR TITLE
Remove trailing ); from primary key statements when reading from file

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -3474,6 +3474,7 @@ sub read_schema_from_file
 			if ($tb_def =~ s/CONSTRAINT\s+([^\s]+)\s+PRIMARY KEY//is) {
 				my $constname = lc($1);
 				$tb_def =~ s/^[^\(]+//;
+				$tb_def =~ s/\);$//s;
 				if ( $tb_def =~ s/USING\s+INDEX\s+TABLESPACE\s+([^\s]+).*//s) {
 					$tb_def =~ s/\s+$//;
 					if ($self->{use_tablespace}) {


### PR DESCRIPTION
The issue before this change was that primary key DDL output when reading from file became:
`ALTER TABLE tbl ADD PRIMARY KEY pk_tbl (tblid));;`

After this change:

`ALTER TABLE tbl ADD PRIMARY KEY pk_tbl (tblid);`

Not sure if it's the correct solution, feel free to modify as appropriate.