### PR TITLE
Add option control the "prefetch" used by oracle_fdw COPY/INSERT

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1412,6 +1412,11 @@ ST_GEOMETRYTYPE_FUNCTION	ST_GEOMETRYTYPE
 # wrapper, you might need to change the name of the schema for each instance.
 FDW_IMPORT_SCHEMA	ora2pg_fdw_import
 
+# The default behaviour of Ora2Pg is to NOT set the "prefetch" option for
+# oracle_fdw when used for COPY and INSERT. This directive allows the prefetch
+# to be set. See oracle_fdw documentation for the current default.
+#ORACLE_FDW_PREFETCH	1000
+
 # By default Ora2Pg drops the temporary schema ora2pg_fdw_import used to import
 # the Oracle foreign schema before each new import. If you want to preserve
 # the existing schema because of modifications or the use of a third party

--- a/doc/Ora2Pg.pod
+++ b/doc/Ora2Pg.pod
@@ -407,6 +407,10 @@ Usage: ora2pg [-dhpqv --estimate_cost --dump_as_html] [--option value]
    --delete clause    : Set the DELETE clause to apply to the Oracle query to
                         be applied before importing data. Can be used multiple
 			time.
+   --oracle_fdw_prefetch: Set the oracle_fdw prefetch value. Larger values
+                        generally result in faster data transfer at the cost
+                        of greater memory utilisation at the destination.
+
 
 See full documentation at https://ora2pg.darold.net/ for more help or see
 manpage with 'man ora2pg'.
@@ -1041,6 +1045,13 @@ Schema where foreign tables for data migration will be created. If you use
 several instances of ora2pg for data migration through the foreign data
 wrapper, you might need to change the name of the schema for each instance.
 Default: ora2pg_fdw_import
+
+=item ORACLE_FDW_PREFETCH
+
+By default Ora2Pg drops the temporary schema ora2pg_fdw_import used to import
+the Oracle foreign schema before each new import. If you want to preserve
+the existing schema because of modifications or the use of a third party
+server, disable this directive.
 
 =item DROP_FOREIGN_SCHEMA
 

--- a/doc/ora2pg.3
+++ b/doc/ora2pg.3
@@ -570,6 +570,9 @@ Usage: ora2pg [\-dhpqv \-\-estimate_cost \-\-dump_as_html] [\-\-option value]
 \&   \-\-delete clause    : Set the DELETE clause to apply to the Oracle query to
 \&                        be applied before importing data. Can be used multiple
 \&                        time.
+\&   \-\-oracle_fdw_prefetch: Set the oracle_fdw prefetch value. Larger values
+\&                        generally result in faster data transfer at the cost
+\&                        of greater memory utilisation at the destination.
 .Ve
 .PP
 See full documentation at https://ora2pg.darold.net/ for more help or see

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -8667,7 +8667,11 @@ sub export_table
 				} elsif ($tmptb =~ s/^([^\.]+)\.//) {
 					$schem = "schema '$1',";
 				}
-				$sql_output .= " SERVER $self->{fdw_server} OPTIONS($schem table '$tmptb', readonly 'true');\n";
+				$sql_output .= " SERVER $self->{fdw_server} OPTIONS($schem table '$tmptb', ";
+				if ($self->{oracle_fdw_prefetch}) {
+					$sql_output .= "prefetch '$self->{oracle_fdw_prefetch}', ";
+			        }
+				$sql_output .= "readonly 'true');\n";
 			}
 		}
 		$sql_output =~ s/#ORA2PGENUM#/$enum_str/s;

--- a/scripts/ora2pg
+++ b/scripts/ora2pg
@@ -95,6 +95,7 @@ my $START_SCN = '';
 my $CDC_READY = '';
 my $CDC_FILE = 'TABLES_SCN.log';
 my $DROP_IF_EXISTS = 0;
+my $ORACLE_FDW_PREFETCH;
 
 my @SCHEMA_ARRAY  = qw( SEQUENCE SEQUENCE_VALUES TABLE PACKAGE VIEW GRANT TRIGGER FUNCTION PROCEDURE TABLESPACE PARTITION TYPE MVIEW DBLINK SYNONYM DIRECTORY );
 my @EXTERNAL_ARRAY  = qw( KETTLE FDW );
@@ -176,6 +177,7 @@ GetOptions (
 	'lo_import!' => \$IMPORT_LO,
 	'drop_if_exists!' => \$DROP_IF_EXISTS,
 	'delete=s' => \@DELETE_CLAUSE,
+	'oracle_fdw_prefetch=i' => \$ORACLE_FDW_PREFETCH,
 );
 
 # Check command line parameters
@@ -398,6 +400,7 @@ my $schema = new Ora2Pg (
 	cdc_file => $CDC_FILE,
 	drop_if_exists => $DROP_IF_EXISTS,
 	delete => join(' ', @DELETE_CLAUSE),
+        oracle_fdw_prefetch => $ORACLE_FDW_PREFETCH,
 );
 
 # Look at configuration file if an input file is defined
@@ -553,6 +556,9 @@ Usage: ora2pg [-dhpqv --estimate_cost --dump_as_html] [--option value]
    --delete clause    : Set the DELETE clause to apply to the Oracle query to
                         be applied before importing data. Can be used multiple
 			time.
+   --oracle_fdw_prefetch: Set the oracle_fdw prefetch value. Larger values
+                        generally result in faster data transfer at the cost
+                        of greater memory utilisation at the destination.
 
 See full documentation at https://ora2pg.darold.net/ for more help or see
 manpage with 'man ora2pg'.


### PR DESCRIPTION
Prior to this change Ora2Pg uses the default "prefetch" of oracle_fdw, which at the time of writing is 50. Allowing this to be controlled by an Ora2Pg configuration/option gives the option of increased performance at the cost of some additional memory on the PostgreSQL side.

In my testing I've seen a 2x speed improvement when setting prefetch to 1000.

Hopefully, my commit covers all the required changes to add a new option. If not, please let me know what is outstanding.