### PR TITLE
Fix issue with multi style comments

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -14566,6 +14566,15 @@ sub _remove_comments
 		# Single line comment --...-- */ is replaced by  */ only
 		$lines[$i] =~ s/^([\t ]*)\-[\-]+\s*\*\//$1\*\//;
 
+      # Check for -- and */ in the same line
+        if ($lines[$i] =~ /(--.*)(\*\/.*)$/)
+        {
+            my $first_part = $1;
+            my $second_part = $2;
+            $lines[$i] = $first_part;
+            splice(@lines, $i + 1, 0, $second_part);
+        }
+		
 		# Single line comment --
 		if ($lines[$i] =~ s/^([\t ]*\-\-.*)$/$1\%ORA2PG_COMMENT$self->{idxcomment}\%/)
 		{


### PR DESCRIPTION
Hi team, 
We have found one issue in the code when we have multi-style comments vis-a-vis single-line and multi-line comments.
 
**Example Problem** 

Suppose we have table ddl like below, when we are trying to convert with ora2pg code we are missing the column "col4" line because of the below-explained reason,
 
_Example ddl:_
```
CREATE TABLE tbname(
col1 int,
/* col2 varchar(20),
-- col3 varchar(20),*/
col4 varchar(20),
/* col5 varchar(20),
col6 int, */
col7 int);
```
_Expected result:_
```
CREATE TABLE tbname (
	col1 numeric(38),
	col4 varchar(20),
	col7 numeric(38)
) ;
```
_Ora2pg Current Result:_
 ```
CREATE TABLE tbname (
	col1 numeric(38),
	col7 numeric(38)
) ;
 ```
 
 
**Issue Overview:**

When we have the end pattern of the block comment in the same line as that of the single line comment (as we have in column 3 line number above) then the end pattern of the block comment as well as single line comment both get replaced when ora2pg changes the commented code to "ORA2PG_COMMENT_{commentnumber}".
 
**Issue Explanation:**

In the first step ora2PG replaces line starting with "--" (single line comment)  with "ORA2PG_COMMENT_{commentnumber}".
Inadvertently it also replaces "*/" which was the end pattern of the block comment.

In the second step, when it tries to replace comments within "/* */" (block comment) it finds the opening comment pattern "/*" in Column 2nd line but the closing comment pattern "*/"  it finds in the 5th column line instead of the 3rd column and it replaces the whole block with "ORA2PG_COMMENT_{commentnumber}"  thus missing valid col4 from final ddl .
Because of this reason, it is missing one column in the output ddl in the provided example code.
 
 
**Solution Implemented:**
 
we are also checking if a DDL line has the single line comment  '--' and it also contains '*/'. if so, then we are giving a line break before */. With this, the end pattern of block comment will remain intact and won't be replaced with single line comment which solves the issue at hand.
 
 
Above issue happens for single file input as well as db Input