### PR TITLE
Fix incorrect "unsupported partition type" warning for oracle_fdw copy

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -9144,7 +9144,11 @@ sub _get_sql_statements
 	{
 		if ($self->{oracle_fdw_data_export} && $self->{pg_dsn} && $self->{drop_foreign_schema})
 		{
+			# Temporarily disable partitioning (if set) to obtain appropriate DDL for the oracle_fdw foreign table
+			my $original_disable_partition = $self->{disable_partition};
+			$self->{disable_partition} = 1;
 			my $fdw_definition = $self->export_table();
+			$self->{disable_partition} = $original_disable_partition;
 			$self->{dbhdest}->do("DROP SCHEMA $self->{pg_supports_ifexists} $self->{fdw_import_schema} CASCADE") or $self->logit("FATAL: " . $self->{dbhdest}->errstr . "\n", 0, 1);
 			$self->{dbhdest}->do("CREATE SCHEMA $self->{fdw_import_schema}") or $self->logit("FATAL: " . $self->{dbhdest}->errstr . "\n", 0, 1);
 			$self->{dbhdest}->do($fdw_definition) or $self->logit("FATAL: " . $self->{dbhdest}->errstr . ", SQL: $fdw_definition\n", 0, 1);


### PR DESCRIPTION
Using Ora2Pg COPY with oracle_fdw on a partitioned table results in the following message: 

> WARNING: unsupported partition type on table '\<table name\>'

Looking into the code I found that "WARNING: unsupported partition type" is only raised in the following block:

```
elsif ($self->{partition_by_reference} eq 'none')
                                {
                                        print STDERR "WARNING: unsupported partition type on table '$table'\n";
                                        $sql_output .=  " -- Unsupported partition type '" . $self->{partitions_list}{"\L$table\E"}{type} . "', please check constraint: " . $self->{partitions_list}{"\L$table\E"}{refconstraint} . "\n";
                                }
```

After some poking around I realised that the partition type is not defined at the point the oracle_fdw table is defined in the following:

```
my $fdw_definition = $self->export_table();
```

My initial attempt to resolve the false warning involved moving the above code to after the partitioning type has been obtained. That resulted in Ora2Pg attempting to create a foreign table with a "PARTITION BY" clause, which is not valid and therefore errors.

It seems the most appropriate approach is to disable the partitioning via `disable_partition` while populating `fdw_definition` and then set `disable_partition` back to its original value, so that's what I've implemented in the commit for this pull request.

I've run a range of tests in an attempt to validate that I've not broken something unexpected. However, my understanding of the code is very limited at this point so please review the approach and modify/reject the pull request as appropriate.