### PR TITLE
Fix validation of nullable boolean columns

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -22120,7 +22120,7 @@ ORDER BY attnum};
 				}
 				if ($prow[$i] == 1) {
 					$prow[$i] = 't';
-				} else {
+				} elsif (defined $prow[$i]) {
 					$prow[$i] = 'f';
 				}
 			}


### PR DESCRIPTION
In validation, only convert DBD::Pg 0 to 'f'. Previously, undef (SQL NULL) was also converted to 'f' which caused validation to fail for boolean columns with NULL values.