### PR TITLE
Remove table alias from column alias after TRIM (fix for Issue #1791)

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -11963,7 +11963,7 @@ sub _howto_get_data
 			}
 			# Apply some default transformation following the data type
 			elsif ( ( $src_type->[$k] =~ /^char/i) && ($type->[$k] =~ /(varchar|text)/i)) {
-				$str .= "trim($self->{trim_type} '$self->{trim_char}' FROM $alias.$name->[$k]) AS $alias.$name->[$k],";
+				$str .= "trim($self->{trim_type} '$self->{trim_char}' FROM $alias.$name->[$k]) AS $name->[$k],";
 			} elsif ($self->{is_mysql} && $src_type->[$k] =~ /bit/i) {
 				$str .= "BIN($alias.$name->[$k]),";
 			}


### PR DESCRIPTION
Small fix to remove the table alias from the column alias after a `TRIM` function being applied to the column (fix for Issue #1791).

Using the table alias when referencing the column in the `SELECT` statement and more specifically in the `TRIM` function is fine (and often necessary). It's only in the the creation of the table alias (after the `AS` keyword) that the table alias cannot be used.

Additional details of problem described in Issue #1791.