### PR TITLE
Expansion of oracle_fdw COPY to support CSV format

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1426,7 +1426,15 @@ FDW_IMPORT_SCHEMA	ora2pg_fdw_import
 # mode should work on any PostgreSQL-based system, including managed offerings,
 # which are not expected to support use of "server" mode due to permissions.
 # The default is "local" as this is compatible with more configurations.
-ORACLE_FDW_BINARY_COPY_MODE	local
+ORACLE_FDW_COPY_MODE	local
+
+# When using Ora2Pg COPY with oracle_fdw it is possible to use either BINARY or
+# CSV data format. BINARY provides better performance, however, requires exact
+# data type matching between the FDW and destination table. CSV provides
+# greater flexibiliity with respect to data type matching: if the FDW and
+# destination data types are functionally-compatible the columns can be copied.
+# The default is "binary".
+ORACLE_FDW_COPY_FORMAT	binary
 
 # By default Ora2Pg drops the temporary schema ora2pg_fdw_import used to import
 # the Oracle foreign schema before each new import. If you want to preserve

--- a/README
+++ b/README
@@ -1029,7 +1029,7 @@ CONFIGURATION
         the prefetch to be set. See oracle_fdw documentation for the current
         default.
 
-    ORACLE_FDW_BINARY_COPY_MODE
+    ORACLE_FDW_COPY_MODE
         When using Ora2Pg COPY with oracle_fdw it is possible to use two
         different modes: 1) "local", which uses psql on the host running
         Ora2Pg for the "TO" binary stream; 2) "server", which uses
@@ -1041,6 +1041,15 @@ CONFIGURATION
         offerings, which are not expected to support use of "server" mode
         due to permissions. The default is "local" as this is compatible
         with more configurations.
+
+    ORACLE_FDW_COPY_FORMAT
+        When using Ora2Pg COPY with oracle_fdw it is possible to use either
+        BINARY or CSV data format. BINARY provides better performance,
+        however, requires exact data type matching between the FDW and
+        destination table. CSV provides greater flexibiliity with respect to
+        data type matching: if the FDW and destination data types are
+        functionally-compatible the columns can be copied. The default is
+        "binary".
 
     DROP_FOREIGN_SCHEMA
         By default Ora2Pg drops the temporary schema ora2pg_fdw_import used

--- a/doc/Ora2Pg.pod
+++ b/doc/Ora2Pg.pod
@@ -1052,7 +1052,7 @@ The default behaviour of Ora2Pg is to NOT set the "prefetch" option for
 oracle_fdw when used for COPY and INSERT. This directive allows the prefetch to
 be set. See oracle_fdw documentation for the current default.
 
-=item ORACLE_FDW_BINARY_COPY_MODE
+=item ORACLE_FDW_COPY_MODE
 
 When using Ora2Pg COPY with oracle_fdw it is possible to use two different
 modes: 1) "local", which uses psql on the host running Ora2Pg for the "TO"
@@ -1063,6 +1063,15 @@ binary stream. Both modes use psql for the "FROM STDIN BINARY". However,
 mode should work on any PostgreSQL-based system, including managed offerings,
 which are not expected to support use of "server" mode due to permissions. The
 default is "local" as this is compatible with more configurations.
+
+=item ORACLE_FDW_COPY_FORMAT
+
+When using Ora2Pg COPY with oracle_fdw it is possible to use either BINARY or
+CSV data format. BINARY provides better performance, however, requires exact
+data type matching between the FDW and destination table. CSV provides greater
+flexibiliity with respect to data type matching: if the FDW and destination
+data types are functionally-compatible the columns can be copied. The default
+is "binary".
 
 =item DROP_FOREIGN_SCHEMA
 

--- a/doc/ora2pg.3
+++ b/doc/ora2pg.3
@@ -55,7 +55,7 @@
 .\" ========================================================================
 .\"
 .IX Title "ORA2PG 1"
-.TH ORA2PG 1 2024-05-21 "perl v5.38.2" "User Contributed Perl Documentation"
+.TH ORA2PG 1 2024-06-10 "perl v5.38.2" "User Contributed Perl Documentation"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -1123,8 +1123,8 @@ Default: ora2pg_fdw_import
 The default behaviour of Ora2Pg is to NOT set the "prefetch" option for
 oracle_fdw when used for COPY and INSERT. This directive allows the prefetch to
 be set. See oracle_fdw documentation for the current default.
-.IP ORACLE_FDW_BINARY_COPY_MODE 4
-.IX Item "ORACLE_FDW_BINARY_COPY_MODE"
+.IP ORACLE_FDW_COPY_MODE 4
+.IX Item "ORACLE_FDW_COPY_MODE"
 When using Ora2Pg COPY with oracle_fdw it is possible to use two different
 modes: 1) "local", which uses psql on the host running Ora2Pg for the "TO"
 binary stream; 2) "server", which uses PostgreSQL server-side COPY for the "TO"
@@ -1134,6 +1134,14 @@ binary stream. Both modes use psql for the "FROM STDIN BINARY". However,
 mode should work on any PostgreSQL-based system, including managed offerings,
 which are not expected to support use of "server" mode due to permissions. The
 default is "local" as this is compatible with more configurations.
+.IP ORACLE_FDW_COPY_FORMAT 4
+.IX Item "ORACLE_FDW_COPY_FORMAT"
+When using Ora2Pg COPY with oracle_fdw it is possible to use either BINARY or
+CSV data format. BINARY provides better performance, however, requires exact
+data type matching between the FDW and destination table. CSV provides greater
+flexibiliity with respect to data type matching: if the FDW and destination
+data types are functionally-compatible the columns can be copied. The default
+is "binary".
 .IP DROP_FOREIGN_SCHEMA 4
 .IX Item "DROP_FOREIGN_SCHEMA"
 By default Ora2Pg drops the temporary schema ora2pg_fdw_import used to import

--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -288,7 +288,9 @@ our @GRANTS = (
 	'EXECUTE'
 );
 
-our @ORACLE_FDW_BINARY_COPY_MODES = qw( local server );
+our @ORACLE_FDW_COPY_MODES = qw( local server );
+
+our @ORACLE_FDW_COPY_FORMATS = qw( binary csv );
 
 $SIG{'CHLD'} = 'DEFAULT';
 
@@ -1006,8 +1008,11 @@ sub _init
 	# oracle_fdw foreign server
 	$self->{fdw_server} = '';
 
-	# oracle_fdw binary copy mode
-	$self->{oracle_fdw_binary_copy_mode} = '';
+	# oracle_fdw copy mode
+	$self->{oracle_fdw_copy_mode} = '';
+
+	# oracle_fdw copy format
+	$self->{oracle_fdw_copy_format} = '';
 
 	# AS OF SCN related variables
 	$self->{start_scn} = $options{start_scn} || '';
@@ -1282,14 +1287,20 @@ sub _init
 		$self->{fdw_server} = 'orcl';
 	}
 
-	# Validate the oracle_fdw binary copy mode and set a default mode if undefined
+	# Validate the oracle_fdw copy mode and format, and set a default mode and format if undefined
         if ($self->{fdw_server} && $self->{type} eq 'COPY') {
-                $self->{oracle_fdw_binary_copy_mode} ||= 'local';
-                $self->{oracle_fdw_binary_copy_mode} = lc($self->{oracle_fdw_binary_copy_mode});
-		if (!grep(/^$self->{oracle_fdw_binary_copy_mode}$/, @ORACLE_FDW_BINARY_COPY_MODES))
+                $self->{oracle_fdw_copy_mode} ||= 'local';
+                $self->{oracle_fdw_copy_mode} = lc($self->{oracle_fdw_copy_mode});
+		if (!grep(/^$self->{oracle_fdw_copy_mode}$/, @ORACLE_FDW_COPY_MODES))
 		{
-			$self->logit("FATAL: Unknown oracle_fdw binary copy mode: $self->{oracle_fdw_binary_copy_mode}. Valid modes: " . join(', ', @ORACLE_FDW_BINARY_COPY_MODES) . "\n",0,1);
-        	}
+			$self->logit("FATAL: Unknown oracle_fdw copy mode: $self->{oracle_fdw_copy_mode}. Valid modes: " . join(', ', @ORACLE_FDW_COPY_MODES) . "\n",0,1);
+		}
+                $self->{oracle_fdw_copy_format} ||= 'binary';
+                $self->{oracle_fdw_copy_format} = lc($self->{oracle_fdw_copy_format});
+		if (!grep(/^$self->{oracle_fdw_copy_format}$/, @ORACLE_FDW_COPY_FORMATS))
+		{
+			$self->logit("FATAL: Unknown oracle_fdw copy format: $self->{oracle_fdw_copy_format}. Valid formats: " . join(', ', @ORACLE_FDW_COPY_FORMATS) . "\n",0,1);
+		}
 	}
 
 	# Set the schema where the foreign tables will be created
@@ -10730,14 +10741,15 @@ sub _dump_fdw_table
 	if ($self->{type} eq 'COPY')
 	# Build COPY statement
 	{
-		$ENV{PGPASSWORD} = $self->{dbpwd};
-		if ($self->{oracle_fdw_binary_copy_mode} eq 'local') {
+		if ($self->{oracle_fdw_copy_mode} eq 'local') {
+			$ENV{PGPASSWORD} = $self->{dbpwd};
 			# Need to escape the quotation marks in $fdwtb
 			my $fdwtb_escaped = $fdwtb =~ s/"/\"/gr;
-			$s_out = "\\copy (select $fdw_col_list from $self->{fdw_import_schema}.$fdwtb_escaped) TO PROGRAM 'psql -X -h $self->{dbhost} -p $self->{dbport} -d $self->{dbname} -U $self->{dbuser} -c \\\"\\copy $self->{schema}.$tmptb FROM STDIN BINARY\\\"' BINARY";
+			$s_out = "\\copy (select $fdw_col_list from $self->{fdw_import_schema}.$fdwtb_escaped) TO PROGRAM 'psql -X -h $self->{dbhost} -p $self->{dbport} -d $self->{dbname} -U $self->{dbuser} -c \\\"\\copy $self->{schema}.$tmptb FROM STDIN " . uc($self->{oracle_fdw_copy_format}) . "\\\"' " . uc($self->{oracle_fdw_copy_format});
 		}
-		if ($self->{oracle_fdw_binary_copy_mode} eq 'server') {
-			$s_out = "COPY (select $fdw_col_list from $self->{fdw_import_schema}.$fdwtb) TO PROGRAM 'psql -h $self->{dbhost} -p $self->{dbport} -d $self->{dbname} -U $self->{dbuser} -c \"\\copy $self->{schema}.$tmptb FROM STDIN BINARY\"' BINARY";
+		if ($self->{oracle_fdw_copy_mode} eq 'server') {
+			#$s_out = "COPY (select $fdw_col_list from $self->{fdw_import_schema}.$fdwtb) TO PROGRAM 'PGPASSWORD=$self->{dbpwd} psql -h $self->{dbhost} -p $self->{dbport} -d $self->{dbname} -U $self->{dbuser} -c \"\\copy $self->{schema}.$tmptb FROM STDIN BINARY\"' BINARY";
+			$s_out = "COPY (select $fdw_col_list from $self->{fdw_import_schema}.$fdwtb) TO PROGRAM 'PGPASSWORD=$self->{dbpwd} psql -h $self->{dbhost} -p $self->{dbport} -d $self->{dbname} -U $self->{dbuser} -c \"\\copy $self->{schema}.$tmptb FROM STDIN " . uc($self->{oracle_fdw_copy_format}) . "\"' " . uc($self->{oracle_fdw_copy_format});
 		}
 	}
 
@@ -10870,7 +10882,7 @@ sub _dump_fdw_table
 					}
 					$dbh->disconnect() if ($dbh);
 				}
-				if ($self->{type} eq 'COPY' and $self->{oracle_fdw_binary_copy_mode} eq 'local')
+				if ($self->{type} eq 'COPY' and $self->{oracle_fdw_copy_mode} eq 'local')
 				{
 					# Need to replace the "?" in $s_out with the relevant integer ("$self->{ora_conn_count}")
 					$s_out =~ s/\?/$self->{ora_conn_count}/;
@@ -10885,7 +10897,7 @@ sub _dump_fdw_table
 						$pipe->print("TABLE EXPORT ENDED: $table, end: $t_time, rows $self->{tables}{$table}{table_info}{num_rows}\n");
 					}
 				}
-				if ($self->{type} eq 'COPY' and $self->{oracle_fdw_binary_copy_mode} eq 'server')
+				if ($self->{type} eq 'COPY' and $self->{oracle_fdw_copy_mode} eq 'server')
 				{
                                 	$self->logit("Creating new connection to extract data in parallel...\n", 1);
                                 	my $dbh = $local_dbh->clone();
@@ -10931,14 +10943,14 @@ sub _dump_fdw_table
 			$self->logit("Exporting foreign table data for $table using query: $s_out\n", 1);
 			$local_dbh->do($s_out) or $self->logit("ERROR: " . $local_dbh->errstr . ", SQL: $s_out\n", 0);
 		}
-		if ($self->{type} eq 'COPY' and $self->{oracle_fdw_binary_copy_mode} eq 'local')
+		if ($self->{type} eq 'COPY' and $self->{oracle_fdw_copy_mode} eq 'local')
 		{
 			$ENV{PGPASSWORD} = $self->{dbpwd};
 			my $psql_cmd = "psql -X -h $self->{dbhost} -p $self->{dbport} -d $self->{dbname} -U $self->{dbuser} -c \"$s_out\"";
 			$self->logit("Exporting foreign table data for $table using psql command: $s_out\n", 1);
 			my $cmd_output = `$psql_cmd` or $self->logit("FATAL: " . $cmd_output . "\n", 0, 1);
 		}
-		if ($self->{type} eq 'COPY' and $self->{oracle_fdw_binary_copy_mode} eq 'server')
+		if ($self->{type} eq 'COPY' and $self->{oracle_fdw_copy_mode} eq 'server')
 		{
 			$self->logit("Exporting foreign table data for $table using query: $s_out\n", 1);
 			$local_dbh->do($s_out) or $self->logit("ERROR: " . $local_dbh->errstr . ", SQL: $s_out\n", 0);


### PR DESCRIPTION
Pull request [1783](https://github.com/darold/ora2pg/pull/1783) added support for using oracle_fdw in combination with psql "\copy" and server-side COPY using BINARY stream. This pull request builds on [1783](https://github.com/darold/ora2pg/pull/1783) to add support for CSV format.

- **BINARY** requires an exact match between the FDW table data types on the destination table data types
- **CSV** allows greater flexibility and supports non-identical data types as long as they are functionally-compatible with respect to the data stored

Key changes in the pull request:

- Rename ORACLE_FDW_BINARY_COPY_MODE to ORACLE_FDW_COPY_MODE: local or server
- Add ORACLE_FDW_COPY_FORMAT: binary or csv
- Fix "server" mode oracle_fdw COPY which was broken by 1e9effc (in server mode the password is only visible via `ps`, etc on the host running PostgreSQL server, which is expected to have highly restricted access in production environments)
- Update documentation