### PR TITLE
add multiple report format output at once

### DIFF
--- a/doc/Ora2Pg.pod
+++ b/doc/Ora2Pg.pod
@@ -373,6 +373,9 @@ Usage: ora2pg [-dhpqv --estimate_cost --dump_as_html] [--option value]
    --dump_as_json     : As above but force ora2pg to dump report in JSON.
    --dump_as_sheet    : Report migration assessment with one CSV line per database.
    --init_project name: Initialise a typical ora2pg project tree. Top directory
+                           dump_as_* selected switches, suffixes
+                           will be .html, .csv, .json.
+   --init_project name: Initialise a typical ora2pg project tree. Top directory
                         will be created under project base dir.
    --project_base dir : Define the base dir for ora2pg project trees. Default
                         is current directory.
@@ -481,8 +484,8 @@ of the command usage:
 It create a generic config file where you just have to define the Oracle
 database connection and a shell script called export_schema.sh. The sources/
 directory will contains the Oracle code, the schema/ will contains the code
-ported to PostgreSQL. The reports/ directory will contains the html reports
-with the migration cost assessment.
+ported to PostgreSQL. The reports/ directory will contains the html and json
+reports with the migration cost assessment.
 
 If you want to use your own default config file, use the -c option to give
 the path to that file. Rename it with .dist suffix if you want ora2pg to
@@ -952,6 +955,30 @@ at command line.
 By default when using SHOW_REPORT the migration report is generated as simple
 text, enabling this directive will force ora2pg to create a report in HTML
 format.
+
+See http://ora2pg.darold.net/report.html for a sample report.
+
+=item DUMP_AS_JSON
+
+By default when using SHOW_REPORT the migration report is generated as simple
+text, enabling this directive will force ora2pg to create a report in JSON
+format.
+See http://ora2pg.darold.net/report.html for a sample report.
+
+=item DUMP_AS_CSV
+
+By default when using SHOW_REPORT the migration report is generated as simple
+text, enabling this directive will force ora2pg to create a report in CSV
+format.
+
+See http://ora2pg.darold.net/report.html for a sample report.
+
+=item DUMP_AS_FILE_PREFIX
+
+By default when using SHOW_REPORT the migration report is generated to stout.
+Enabling this directive in conjunction with DUMP_AS_* directives will force
+ora2pg to create a report files with the given extensions and formats. This
+option allows you to combine multiple DUMP_AS_* formats.
 
 See http://ora2pg.darold.net/report.html for a sample report.
 

--- a/doc/ora2pg.3
+++ b/doc/ora2pg.3
@@ -535,6 +535,9 @@ Usage: ora2pg [\-dhpqv \-\-estimate_cost \-\-dump_as_html] [\-\-option value]
 \&   \-\-dump_as_csv      : As above but force ora2pg to dump report in CSV.
 \&   \-\-dump_as_json     : As above but force ora2pg to dump report in JSON.
 \&   \-\-dump_as_sheet    : Report migration assessment with one CSV line per database.
+\&   \-\-dump_as_file_prefix : Filename prefix, suffix will be added depending on
+\&                             dump_as_* selected switches, suffixes
+\&                             will be .html, .csv, .json.
 \&   \-\-init_project name: Initialise a typical ora2pg project tree. Top directory
 \&                        will be created under project base dir.
 \&   \-\-project_base dir : Define the base dir for ora2pg project trees. Default
@@ -1105,6 +1108,28 @@ at command line.
 By default when using \s-1SHOW_REPORT\s0 the migration report is generated as simple
 text, enabling this directive will force ora2pg to create a report in \s-1HTML\s0
 format.
+.Sp
+See http://ora2pg.darold.net/report.html for a sample report.
+.IP "\s-1DUMP_AS_JSON\s0" 4
+.IX Item "DUMP_AS_JSON"
+By default when using \s-1SHOW_REPORT\s0 the migration report is generated as simple
+text, enabling this directive will force ora2pg to create a report in \s-1JSON\s0
+format.
+.Sp
+See http://ora2pg.darold.net/report.html for a sample report.
+.IP "\s-1DUMP_AS_CSV\s0" 4
+.IX Item "DUMP_AS_CSV"
+By default when using \s-1SHOW_REPORT\s0 the migration report is generated as simple
+text, enabling this directive will force ora2pg to create a report in \s-1CSV\s0
+format.
+.Sp
+See http://ora2pg.darold.net/report.html for a sample report.
+.IP "\s-1DUMP_AS_FILE_PREFIX\s0" 4
+.IX Item "DUMP_AS_FILE_PREFIX"
+By default when using \s-1SHOW_REPORT\s0 the migration report is generated to stout.
+Enabling this directive in conjunction with \s-1DUMP_AS_*\s0 directives will force
+ora2pg to create a report files with the given extensions and formats. This
+option allows you to combine multiple \s-1DUMP_AS_*\s0 formats.
 .Sp
 See http://ora2pg.darold.net/report.html for a sample report.
 .IP "\s-1HUMAN_DAYS_LIMIT\s0" 4

--- a/scripts/ora2pg
+++ b/scripts/ora2pg
@@ -64,6 +64,7 @@ my $COST_UNIT_VALUE = 5;
 my $DUMP_AS_HTML;
 my $DUMP_AS_CSV;
 my $DUMP_AS_JSON;
+my $DUMP_AS_FILE_PREFIX;
 my $DUMP_AS_SHEET;
 my $THREAD_COUNT;
 my $ORACLE_COPIES;
@@ -164,6 +165,7 @@ GetOptions (
 	'dump_as_csv!' =>\$DUMP_AS_CSV,
 	'dump_as_json!' =>\$DUMP_AS_JSON,
 	'dump_as_sheet!' =>\$DUMP_AS_SHEET,
+	'dump_as_file_prefix=s' =>\$DUMP_AS_FILE_PREFIX,
 	'init_project=s' => \$CREATE_PROJECT,
 	'project_base=s' => \$PROJECT_BASE,
 	'print_header!' => \$PRINT_HEADER,
@@ -377,6 +379,7 @@ my $schema = new Ora2Pg (
 	dump_as_csv => $DUMP_AS_CSV,
 	dump_as_json => $DUMP_AS_JSON,
 	dump_as_sheet => $DUMP_AS_SHEET,
+	dump_as_file_prefix => $DUMP_AS_FILE_PREFIX,
 	thread_count => $THREAD_COUNT,
 	oracle_copies => $ORACLE_COPIES,
 	data_limit => $DATA_LIMIT,
@@ -528,6 +531,9 @@ Usage: ora2pg [-dhpqv --estimate_cost --dump_as_html] [--option value]
    --dump_as_csv      : As above but force ora2pg to dump report in CSV.
    --dump_as_json     : As above but force ora2pg to dump report in JSON.
    --dump_as_sheet    : Report migration assessment with one CSV line per database.
+   --dump_as_file_prefix : Filename prefix, suffix will be added depending on
+                           dump_as_* selected switches, suffixes
+                           will be .html, .csv, .json.
    --init_project name: Initialise a typical ora2pg project tree. Top directory
                         will be created under project base dir.
    --project_base dir : Define the base dir for ora2pg project trees. Default


### PR DESCRIPTION
-this is the text from #1826 -

Hello,

ora2pg generates reports in multiple formats with `-t SHOW_REPORT` . Those formats are mutual exclusives at run time and there's no other way to generate multiple formats outputs at once.

Proposition:

The project is not to modify ora2pg behaviour but having a "file-prefix" switch allowing multiple output files target :
`--dump_as_file_prefix=db-report` used in conjunction with `--dump_as_html` and `--dump_as_json` should generate `db-report.html` and `db-report.json` files with the corresponding format.

I'll provide a patch just after submitting this improvement.