### PR TITLE
Handling XMLELEMENT Conversion

### DIFF
--- a/lib/Ora2Pg/PLSQL.pm
+++ b/lib/Ora2Pg/PLSQL.pm
@@ -1932,7 +1932,7 @@ sub replace_oracle_function
 	# Remove call to getClobVal() or getStringVal, no need of that
 	$str =~ s/\.(GETCLOBVAL|GETSTRINGVAL|GETNUMBERVAL|GETBLOBVAL)\s*\(\s*\)//is;
 	# Add the name keyword to XMLELEMENT
-	$str =~ s/XMLELEMENT\s*\(\s*(!NAME)/XMLELEMENT(name $1/is;
+	$str =~ s/XMLELEMENT\s*\(\s*(?:NAME\s+)?([^\)]+)/XMLELEMENT(name $1/is;
 	# Replace XMLTYPE function
 	$str =~ s/XMLTYPE\s*\(\s*([^,]+)\s*,[^\)]+\s*\)/xmlparse(DOCUMENT, convert_from($1, 'utf-8'))/igs;
 	$str =~ s/XMLTYPE\.CREATEXML\s*\(\s*[^\)]+\s*\)/xmlparse(DOCUMENT, convert_from($1, 'utf-8'))/igs;


### PR DESCRIPTION
Issues in converting xmlelement
 
Issue:  
In version 24.0, the conversion of `xmlelement` from Oracle to PostgreSQL worked without any issues. However, in version 24.3, the syntax conversion for `xmlelement` is incorrect.
 
Problem: 
In Oracle, the syntax is `xmlelement(`, while in PostgreSQL, it should be `xmlelement(name `. The conversion in 24.3 does not reflect this properly.
 
Details:  
In the `plsql.pm` file under sub replace_oracle_function(), the regex for converting `xmlelement` is written as follows:  
 
$str =~ s/XMLELEMENT\s*\(\s*(!NAME)/XMLELEMENT(name $1/is;
 
Here, `(!NAME)` is treated as a capturing group, and this leads to the incorrect conversion of `xmlelement`.
 
Solution:
After reviewing previous commits, we found that the issue arose from the duplication of `NAME`. To fix this, we will modify the regex to make `(!NAME)` a non-capturing group, ensuring that it does not affect the conversion. This adjustment will allow the conversion to work correctly.
changed pattern is as below:
$str =~ s/XMLELEMENT\s*\(\s*(?:NAME\s+)?([^\)]+)/XMLELEMENT(name $1/is;