### PR TITLE
Handling Timestamp Datatype

### DIFF
--- a/lib/Ora2Pg/Oracle.pm
+++ b/lib/Ora2Pg/Oracle.pm
@@ -2078,6 +2078,18 @@ sub _sql_type
 		}
 	}
 
+	# handing timestamp with local timezone
+	my $captured_type = '';
+	if($type =~ /TIMESTAMP\s*\((\d+)\) WITH LOCAL TIME ZONE/i){
+		$type =~ s/TIMESTAMP\s*\((\d+)\) WITH LOCAL TIME ZONE/TIMESTAMP WITH LOCAL TIME ZONE/ig;
+		$captured_type = $1;
+		my $res_type = $self->{data_type}{$type};
+		my @res_ = split(/\s+/,$res_type);
+		$res_[0] .= "($captured_type)";
+		my $r_type = join(' ',@res_);
+		$type = uc($r_type);
+	}
+
 	if (exists $self->{data_type}{$type})
 	{
 


### PR DESCRIPTION
Issue in Data Type Conversion (TIMESTAMP WITH LOCAL TIMEZONE)
 
Issue:  
In version 24.0, the `TIMESTAMP WITH LOCAL TIME ZONE` data type was converting correctly due to specific handling in the code. However, in version 24.3, this data type no longer converts as expected, due to changes in the `_sql_type` subroutine in `Oracle.pm`.
 
Example:
 
Input:
 
CREATE TABLE example_table (
    id NUMBER PRIMARY KEY,
    event_time TIMESTAMP WITH LOCAL TIME ZONE
);
 
 
Expected Output:
 
CREATE TABLE example_table (
    id SERIAL PRIMARY KEY,
    event_time TIMESTAMP WITH TIMEZONE
);
 
 
Converted Output:
 
CREATE TABLE example_table (
    id SERIAL PRIMARY KEY,
    event_time TIMESTAMP WITH LOCAL TIMEZONE
);
 
 
Solution: 
Added a dedicated condition in the sub _sql_type() within `Oracle.pm` to handle this specific data type conversion without affecting other code changes.
Line number 2081 to 2092 reflect our changes in oracle.pm