### PR TITLE
Handling Referencing in Triggers

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -3707,7 +3707,7 @@ sub read_trigger_from_file
 		} elsif ($trigger =~ s/REFERENCING\s+(.*?)(FOR\s+EACH\s+)/$2/is) {
 			$t_referencing = " REFERENCING $1";
 		}
-		$t_referencing =~ s/REFERENCING\s+(NEW|OLD)\s+AS\s+(NEW|OLD)\s+(NEW|OLD)\s+AS\s+(NEW|OLD)//gsi;
+		$t_referencing =~ s/REFERENCING\s+(NEW|OLD)\s+AS\s+(NEW|OLD)(\s+(NEW|OLD)\s+AS\s+(NEW|OLD))?//gsi;
 
 		if ($trigger =~ s/^\s*(FOR\s+EACH\s+)(ROW|STATEMENT)\s*//is) {
 			$t_type = $1 . $2;
@@ -5821,7 +5821,7 @@ sub export_trigger
 				$statement = 1 if ($trig->[1] =~ s/ STATEMENT//);
 				$sql_output .= "$trig->[1] $trig->[2]$cols ON " . $self->quote_object_name($tbname) . " ";
 				if ($trig->[6] =~ s/.*(REFERENCING\s+.*)/$1/is) {
-					$trig->[6] =~ s/REFERENCING\s+(NEW|OLD)\s+AS\s+(NEW|OLD)\s+(NEW|OLD)\s+AS\s+(NEW|OLD)//gsi;
+					$trig->[6] =~ s/REFERENCING\s+(NEW|OLD)\s+AS\s+(NEW|OLD)(\s+(NEW|OLD)\s+AS\s+(NEW|OLD))?//gsi;
 					$trig->[6] =~ s/\s+FOR EACH ROW//gsi;
 					$sql_output .= "$trig->[6] ";
 				}


### PR DESCRIPTION
Issues in Trigger Syntax ( REFERENCING OLD AS OLD NEW AS NEW is not supported in postgres)
 
Issue Summary:
In PostgreSQL, the `REFERENCING OLD AS OLD` or `REFERENCING NEW AS NEW` syntax is not supported in triggers, but ora2pg is not automatically removing it during conversion. This is causing syntax errors.
We can have REFERENCING OLD AS OLD NEW AS NEW or vice versa and the substitution works fine and replaces the old and new keywords.
But when we have a scenario where we will just have NEW AS NEW or OLD AS OLD in ddl and both ain't together then the substitution is failing as the second occurence has not been made optional.
 
Example:
 
Input:
 
CREATE OR REPLACE TRIGGER trigger_name
BEFORE INSERT OR UPDATE ON table_name
FOR EACH ROW
REFERENCING OLD AS OLD 
BEGIN
    IF :NEW.column_name != :OLD.column_name THEN
        -- Trigger logic here
    END IF;
END;
 
Expected Output:
 
CREATE OR REPLACE FUNCTION trigger_function_name()
RETURNS TRIGGER AS $$
BEGIN
    IF NEW.column_name IS DISTINCT FROM OLD.column_name THEN
        -- Trigger logic here
    END IF;
    RETURN NEW;  -- Use RETURN OLD for DELETE triggers
END;
$$ LANGUAGE plpgsql;
 
CREATE TRIGGER trigger_name
BEFORE INSERT OR UPDATE ON table_name
FOR EACH ROW
EXECUTE FUNCTION trigger_function_name();
 
 
Current ora2pg Output:
 
CREATE OR REPLACE FUNCTION trigger_function_name()
RETURNS TRIGGER AS $$
BEGIN
    IF NEW.column_name IS DISTINCT FROM OLD.column_name THEN
        -- Trigger logic here
    END IF;
    RETURN NEW;  -- Use RETURN OLD for DELETE triggers
END;
$$ LANGUAGE plpgsql;
 
CREATE TRIGGER trigger_name
BEFORE INSERT OR UPDATE ON table_name
FOR EACH ROW
REFERENCING OLD AS OLD
EXECUTE FUNCTION trigger_function_name();
 
 
Solution:
To resolve this, adjust this regex pattern `REFERENCING\s+(NEW|OLD)\s+AS\s+(NEW|OLD)\s+(NEW|OLD)\s+AS\s+(NEW|OLD)` making second occurence of (NEW|OLD)\s+(NEW|OLD)\s+AS\s+(NEW|OLD) as optional. This change in `sub export_trigger()` and `sub read_trigger_from_file()` ensures the syntax converts correctly.