### PR TITLE
Handling Group By and Having Clause inside subqueries (HAVING Clause Misplacement in Ora2Pg)

### DIFF
--- a/lib/Ora2Pg/PLSQL.pm
+++ b/lib/Ora2Pg/PLSQL.pm
@@ -985,7 +985,9 @@ sub plsql_to_plpgsql
 	#$str =~ s/\%ROWTYPE//isg;
 
 	# Normalize HAVING ... GROUP BY into GROUP BY ... HAVING clause	
-	$str =~ s/\bHAVING\b((?:(?!SELECT|INSERT|UPDATE|DELETE|WHERE|FROM).)*?)\bGROUP BY\b((?:(?!SELECT|INSERT|UPDATE|DELETE|WHERE|FROM).)*?)((?=UNION|ORDER BY|LIMIT|INTO |FOR UPDATE|PROCEDURE|\)\s+(?:AS)*[a-z0-9_]+\s+)|$)/GROUP BY$2 HAVING$1/gis;
+	# $str =~ s/\bHAVING\b((?:(?!SELECT|INSERT|UPDATE|DELETE|WHERE|FROM).)*?)\bGROUP BY\b((?:(?!SELECT|INSERT|UPDATE|DELETE|WHERE|FROM).)*?)((?=UNION|ORDER BY|LIMIT|INTO |FOR UPDATE|PROCEDURE|\)\s+(?:AS)*[a-z0-9_]+\s+)|$)/GROUP BY$2 HAVING$1/gis;
+	# Modified Regex that can hanlle group by and having when having clause inside subquery
+	$str =~ s/\bHAVING\b((?:(?!SELECT|INSERT|UPDATE|DELETE|WHERE|FROM|\().)*?)\bGROUP BY\b((?:(?!SELECT|INSERT|UPDATE|DELETE|WHERE|FROM|\().)*?)((?=UNION|ORDER BY|LIMIT|INTO |FOR UPDATE|PROCEDURE|\)\s+(?:AS)*[a-z0-9_]+\s+)|$)/GROUP BY$2 HAVING$1/gis;
 
 	# Add STRICT keyword when select...into and an exception with NO_DATA_FOUND/TOO_MANY_ROW is present
 	#$str =~ s/\b(SELECT\b[^;]*?INTO)(.*?)(EXCEPTION.*?(?:NO_DATA_FOUND|TOO_MANY_ROW))/$1 STRICT $2 $3/igs;


### PR DESCRIPTION
**Issue: HAVING Clause Misplacement in Ora2Pg**

**Problem:**
In ora2pg, the HAVING clause inside subqueries was incorrectly swapped with GROUP BY. This happened because the regex didn’t account for parentheses (, leading to broken SQL logic.

**Example of the Issue**
**Input Query (Correct):**
SELECT col1 FROM tb WHERE (col1) IN (
    SELECT col2 FROM tbb GROUP BY col2 HAVING COUNT(col2) > 1
) GROUP BY col1;
Before Fix (Incorrect Output):
SELECT col1 FROM tb WHERE (col1) IN (
    SELECT col2 FROM tbb GROUP BY col2 GROUP BY col1 HAVING COUNT(col2) > 1
);
The HAVING clause inside the subquery was moved incorrectly, breaking the logic.
The existing regex didn’t handle parentheses, causing incorrect swaps inside subqueries.

**Old Regex:**
$str =~ s/\bHAVING\b((?:(?!SELECT|INSERT|UPDATE|DELETE|WHERE|FROM).)*?)\bGROUP BY\b((?:(?!SELECT|INSERT|UPDATE|DELETE|WHERE|FROM).)*?)((?=UNION|ORDER BY|LIMIT|INTO |FOR UPDATE|PROCEDURE|\)\s+(?:AS)*[a-z0-9_]+\s+)|$)/GROUP BY$2 HAVING$1/gis;

**Solution Implemented**
Added \( to the regex to prevent swapping inside subqueries.
**Fixed Regex:**
Updated in PLSQL.pm under plsql_to_plpgsql() at line 990.
$str =~ s/\bHAVING\b((?:(?!SELECT|INSERT|UPDATE|DELETE|WHERE|FROM|\().)*?)\bGROUP BY\b((?:(?!SELECT|INSERT|UPDATE|DELETE|WHERE|FROM|\().)*?)((?=UNION|ORDER BY|LIMIT|INTO |FOR UPDATE|PROCEDURE|\)\s+(?:AS)*[a-z0-9_]+\s+)|$)/GROUP BY$2 HAVING$1/gis;

**Result**
**After Fix (Correct Output):**
SELECT col1 FROM tb WHERE (col1) IN (
    SELECT col2 FROM tbb GROUP BY col2 HAVING COUNT(col2) > 1
) GROUP BY col1;
This Fix Preserves subquery logic having(GROUP BY and HAVING) and ensures proper integrity of ddl.
