### PR TITLE
Change call of parse_config so $self exists

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -925,7 +925,7 @@ sub _init
 		{
 			next if ($o =~ /^options\s*=/i);
 			$o =~ s/\s*=\s*/\t/;
-			&parse_config($o);
+			$self->parse_config($o);
 		}
 		delete $options{options};
 	}
@@ -14840,14 +14840,14 @@ sub read_config
 		$l =~ s/^\s*\#.*$//g;
 		next if (!$l || ($l =~ /^\s+$/));
 		$l =~ s/^\s*//; $l =~ s/\s*$//;
-		&parse_config($l);
+		$self->parse_config($l);
 	}
 	$self->close_export_file($fh);
 }
 
-sub  parse_config
+sub parse_config
 {
-	my $l = shift;
+	my ($self, $l) = @_;
 
 	my ($var, $val) = split(/\s+/, $l, 2);
 	$var = uc($var);


### PR DESCRIPTION
In parse_config `$self` is not initialised, leading to errors if `$self->logit` or `$self->read_config` is called.

To fix this I've modified the calls to parse_config to use the -> pattern as well, and set `$self` & `$l` from `$@_`

I hope this is a good way to do it, my Perl is pretty rusty.