### PR TITLE
Handling Case-Sensitive Column Names in Views

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -3807,7 +3807,8 @@ sub read_view_from_file
 	        $self->{views}{$v_name}{text} = $v_def;
 	        $self->{views}{$v_name}{iter} = $tid;
 		# Remove constraint
-		while ($v_alias =~ s/(,[^,\(]+\(.*)$//) {};
+		# while ($v_alias =~ s/(,[^,\(]+\(.*)$//) {};
+		while ($v_alias =~ s/(,[^,"\(]+\(.*\))$//) {};
 		my @aliases = split(/\s*,\s*/, $v_alias);
 		foreach (@aliases)
 		{
@@ -5126,6 +5127,22 @@ sub export_view
 			$sql_output .= "CREATE$self->{create_or_replace} VIEW $tmpv (";
 			my $count = 0;
 			my %col_to_replace = ();
+			# need to write the condition if views alias as mentioned within ""
+			if (exists $self->{views}{$view}{alias}) {
+				my $alias_ref = $self->{views}{$view}{alias};
+
+				if (ref($alias_ref) eq 'ARRAY') {
+					my @flattened_alias;
+
+					foreach my $sub_array (@$alias_ref) {
+						if (ref($sub_array) eq 'ARRAY') {
+							push @flattened_alias, join(" ", @$sub_array);
+						}
+					}
+					$self->{views}{$view}{alias} = [ map { [$_] } @flattened_alias ];
+
+				}
+			}
 			foreach my $d (@{$self->{views}{$view}{alias}})
 			{
 				if ($count == 0) {
@@ -5152,7 +5169,16 @@ sub export_view
 				$cost_value += $cost;
 				$sql_output .= "\n-- Estimed cost of view [ $view ]: " . sprintf("%2.2f", $cost);
 			}
-			$sql_output .= "\n";
+			# $sql_output .= "\n";
+			# writing if condition that the fname is like "abc.def" --> handling these kind of strings	
+			if ($fname =~ /"[^"]*?(?:\.\s|\.|)[^"]*?"/)
+			{
+				$sql_output .= $fname;
+			}
+			else
+			{
+				$sql_output .= $self->quote_object_name($fname);
+			}
 		}
 
 		if ($self->{force_owner})


### PR DESCRIPTION
Problem:
When converting Oracle views using Ora2Pg, column names enclosed in double quotes ("") are not handled correctly. 
This leads to:
Loss of case sensitivity.
Missing double quotes in column names.
Incorrect parsing of column names containing dots ("."), e.g., "Employee. ID".

Example:

Oracle Input:

CREATE OR REPLACE VIEW emp_view (
    "Employee. ID",
    "Employee First Name",
    "Employee Last Name",
    "Department. ID"
) AS
SELECT employee_id, first_name, last_name, department_id FROM employees;

Ora2Pg Output:

CREATE OR REPLACE VIEW emp_view (employee., employee, employee, department.) AS ...

Solution Implemented:
Updated export_views() to retain double-quoted column names.Used flattening logic to preserve case and special characters.
Added handling in read_trigger_from_file() to correctly parse quoted column names, especially those with dots (".").