### PR TITLE
Handling Single-Line Comments in Table DDL

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -8896,7 +8896,15 @@ sub export_table
 						}
 					}
 				}
-				$sql_output .= ",\n";
+				# $sql_output .= ",\n";
+				if ($f->[4] =~ /--\s*\S+/)
+				{
+					$sql_output .= "\n,";
+				}
+				else
+				{
+					$sql_output .= ",\n";
+				}
 
 				# Replace default generated value on update by a trigger
 				if ($f->[12] =~ /^DEFAULT_GENERATED on update (.*)/i) {


### PR DESCRIPTION
Problem:
In Oracle table DDL, when single-line comments (--) are used after columns, Ora2Pg places commas after the comments.
This causes syntax errors in the converted PostgreSQL DDL. This occurs when fetching from source db.

Example:

Oracle Input:
CREATE TABLE employees (
    employee_id     NUMBER PRIMARY KEY,
    first_name      VARCHAR2(50) -- fname
	,
    last_name       VARCHAR2(50) -- lname
	,
    hire_date       DATE
);

Incorrect Ora2Pg Output:
CREATE TABLE employees (
    employee_id     INTEGER PRIMARY KEY,
    first_name      VARCHAR(50) -- fname,
    last_name       VARCHAR(50) -- lname,
    hire_date       DATE
);

Solution:
Updated logic to detect single-line comments during DDL reconstruction. Ensured that commas are placed before comments or moved to the next line if needed. Prevented syntax issues in PostgreSQL due to misplaced commas.