### PR TITLE
Replaced the ON CONFLICT DO NOTHING logic with ON CONFLICT DO UPDATE to implement UPSERT

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -10872,7 +10872,10 @@ sub _dump_table
 			$s_out =~ s/,$//;
 			$s_out .= ")";
 			if ($self->{insert_on_conflict}) {
-				$s_out .= " ON CONFLICT DO NOTHING";
+				# Use the primary key columns dynamically instead of hardcoding 'ida2a2'
+				my @pk_cols = @{ $self->{tables}{$table}{pg_colnames_pkey} };
+				my @update_cols = grep { my $col = $_; !grep { $_ eq $col } @pk_cols } @{ $self->{tables}{$table}{dest_column_name} };
+				$s_out .= " ON CONFLICT (" . join(',', @pk_cols) . ") DO UPDATE SET " . join(',', map { "$_ = EXCLUDED.$_" } @update_cols);
 			}
 			$sprep = $s_out;
 		}


### PR DESCRIPTION
Dynamically use of primary keys for conflict.
Only in prepared statement code branch.