### PR TITLE
Include FLOAT to Oracle decimal format with leading 0

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -22935,7 +22935,7 @@ ORDER BY attnum};
 				$prow[$i] =~ s/[ ]+$//;
 			}
 			# Oracle can report decimal as .nn, PG always have a 0 at startup
-			if ($self->{colinfo}{$tb}{data_type}{$i+1} eq 'NUMBER') {
+			if ($self->{colinfo}{$tb}{data_type}{$i+1} =~ /^(NUMBER|FLOAT)$/i) {
 				$orow[$i] =~ s/^([\-]?)(\.\d+)/${1}0$2/;
 			}
 		}


### PR DESCRIPTION
Our data validation failed because we have Oracle rows of type FLOAT and in the data validation check, we had the difference with the leading 0. I saw this was already fixed for type NUMBER. So I added the type FLOAT and now our data validation check is successful.