### PR TITLE
Fix prepared (pg_dsn on) blob_to_lo escape

### DIFF
--- a/lib/Ora2Pg.pm
+++ b/lib/Ora2Pg.pm
@@ -12449,7 +12449,7 @@ sub _howto_get_data
 	if ($self->{replace_query}{"\L$table\E"})
 	{
 		$str = $self->{replace_query}{"\L$table\E"};
-		$self->logit("DEGUG: Query sent to $self->{sgbd_name}: $str\n", 1);
+		$self->logit("DEBUG: Query sent to $self->{sgbd_name}: $str\n", 1);
 		return $str;
 	}
 
@@ -12993,7 +12993,7 @@ END;
 		}
 	}
 
-	$self->logit("DEGUG: Query sent to $self->{sgbd_name}: $str\n", 1);
+	$self->logit("DEBUG: Query sent to $self->{sgbd_name}: $str\n", 1);
 
 	return $str;
 }
@@ -13015,7 +13015,7 @@ sub _howto_get_fdw_data
 	if ($self->{replace_query}{"\L$table\E"})
 	{
 		$str = $self->{replace_query}{"\L$table\E"};
-		$self->logit("DEGUG: Query sent to $self->{sgbd_name}: $str\n", 1);
+		$self->logit("DEBUG: Query sent to $self->{sgbd_name}: $str\n", 1);
 		return $str;
 	}
 
@@ -13183,7 +13183,7 @@ sub _howto_get_fdw_data
 		}
 	}
 
-	$self->logit("DEGUG: Query sent to $self->{sgbd_name}: $str\n", 1);
+	$self->logit("DEBUG: Query sent to $self->{sgbd_name}: $str\n", 1);
 
 	return $str;
 }
@@ -14306,7 +14306,7 @@ sub format_data_row
 		{
 			$row->[$idx] = $self->format_data_type($row->[$idx], $data_type, $action, $table, $src_data_types->[$idx], $idx, $colcond->[$idx], $sprep);
 
-			# Construct a WHERE clause based onb PK columns values
+			# Construct a WHERE clause based on PK columns values
 			if ($self->{lo_import} && $colcond->[$idx]->{isoid} && $colcond->[$idx]->{blob})
 			{
 				# Store the uuid of the file containing the BLOB and set the oid to 0


### PR DESCRIPTION
I was having this error when trying to import blobs directly from the ORACLE to the PG base with `-t INSERT --blob_to_lo` options (and therefore PG_DSN also active):

```
[2025-10-14 15:03:35] DEBUG: Sending INSERT bulk output directly to PostgreSQL backend
[2025-10-14 15:03:35] FATAL: ERROR:  invalid hexadecimal digit: "'"
CONTEXT:  unnamed portal with parameters: $1 = '232401', $2 = 'E''<my hex data>''', $3 = '5', $4 = NULL, $5 = NULL, $6 = NULL
```

Last line is the postgres prepared statement execution data log.

I located the issue in the `_escape_lob()` method, that was putting the `E'v'` pattern where v is the value, even when we were using prepared statements in the case the blob_to_lo option is active.

Note that when the source column is a BLOB and the destinaton column an `oid`, the `lo_from_bytea(n, v)` wrapping is probably done in `_dump_table`, not in the `_escape_lob  method, thus I did not touch that part of the script.

PS: I also fixed a few typos I came to see when testing and reading the code, feel free to reject the commit if it's ill advised.

Note that as before we could not combine the options `STANDARD_CONFORMING_STRINGS` with PG_DSN when doing INSERT, now we cannot combine it with blob_to_lo and pg_dsn either

Thanks for reading, and thanks for the awesome script.

## Testing

I of course tested my usecase worked, but I also quickly checked if I break nothing in the process.

The suggested solution is the same as doing this naive modification: (keeping the original structure and putting a last elsif conditions that target only my usecase)

```
			if (!$self->{blob_to_lo})
			{
				if (!$self->{pg_dsn}) {
					$col = "decode($col, 'hex')";
				}
				else
				{
					# with prepare just send the data
					$col =~ s/^[E]?'//;
					$col =~ s/'$//;
				}
			}
			elsif (!$self->{pg_dsn})
			{
				$col = "lo_from_bytea(0, decode($col, 'hex'))";
			}
			# If prepared and blob_to_lo, just send the data
			elsif ($self->{pg_dsn} && $self->{blob_to_lo}) {
				$col =~ s/^[Ee]?'//;
				$col =~ s/'$//;
			}
```
I unit tested the ingenuous and the proposed solutions using this python script:

```py
def v1(pg_dsn, blob_to_lo):
    if pg_dsn:
        return 1
    elif not blob_to_lo:
        return 2
    else:
        return 3
		
def v2(pg_dsn, blob_to_lo):
    if not blob_to_lo:
        if not pg_dsn:
           return 2
        else:
           return 1
    elif not pg_dsn:
        return 3
    elif pg_dsn and blob_to_lo:
        return 1
    
if __name__ == "__main__":
    a = True
    b = True
    print(f' a = {a}, b = {b} : {v1(a, b) == v2(a, b)}')

    a = True
    b = False
    print(f' a = {a}, b = {b} : {v1(a, b) == v2(a, b)}')

    a = False
    b = True
    print(f' a = {a}, b = {b} : {v1(a, b) == v2(a, b)}')

    a = False
    b = False
    print(f' a = {a}, b = {b} : {v1(a, b) == v2(a, b)}')
```

It's giving me the green light:

```bash
$ python test_cond.py
 a = True, b = True : True
 a = True, b = False : True
 a = False, b = True : True
 a = False, b = False : True
```


